### PR TITLE
Add support for individual Miniboss RTA presets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ smhackgtclassic:
 smhack14ice:
 	cp resources/sm_orig.sfc build/smhack20_14ice.sfc && cd src && asar --no-title-check -DFEATURE_SD2SNES=0 -DCATEGORY=4 main.asm ../build/smhack20_14ice.sfc && cd -
 
+smhackminiboss:
+	cp resources/sm_orig.sfc build/smhack20_miniboss.sfc && cd src && asar --no-title-check -DFEATURE_SD2SNES=0 -DCATEGORY=5 main.asm ../build/smhack20_miniboss.sfc && cd -
+
 sd2snes:
 	cp resources/sm_orig.sfc build/smhack20_sd2snes.sfc && cd src && asar --no-title-check -DFEATURE_SD2SNES=1 -DCATEGORY=0 main.asm ../build/smhack20_sd2snes.sfc && cd -
 
@@ -28,4 +31,7 @@ sd2snesgtclassic:
 sd2snes14ice:
 	cp resources/sm_orig.sfc build/smhack20_sd2snes_14ice.sfc && cd src && asar --no-title-check -DFEATURE_SD2SNES=1 -DCATEGORY=4 main.asm ../build/smhack20_sd2snes_14ice.sfc && cd -
 
-all: sd2snes smhack sd2snesrbo smhackrbo sd2sneskpdr25 smhackkpdr25 sd2snesgtclassic smhackgtclassic sd2snes14ice smhack14ice
+sd2snesminiboss:
+	cp resources/sm_orig.sfc build/smhack20_sd2snes_miniboss.sfc && cd src && asar --no-title-check -DFEATURE_SD2SNES=1 -DCATEGORY=5 main.asm ../build/smhack20_sd2snes_miniboss.sfc && cd -
+
+all: sd2snes smhack sd2snesrbo smhackrbo sd2sneskpdr25 smhackkpdr25 sd2snesgtclassic smhackgtclassic sd2snes14ice smhack14ice sd2snesminiboss smhackminiboss

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,6 +55,8 @@ steps:
     python3 lipx.py -c resources/sm_orig.sfc build/smhack20_sd2snes_gtclassic.sfc website/ClientApp/src/files/saveStatePatchGtclassic.ips
     python3 lipx.py -c resources/sm_orig.sfc build/smhack20_14ice.sfc website/ClientApp/src/files/noSaveStatePatch14ice.ips
     python3 lipx.py -c resources/sm_orig.sfc build/smhack20_sd2snes_14ice.sfc website/ClientApp/src/files/saveStatePatch14ice.ips
+    python3 lipx.py -c resources/sm_orig.sfc build/smhack20_miniboss.sfc website/ClientApp/src/files/noSaveStatePatchMiniboss.ips
+    python3 lipx.py -c resources/sm_orig.sfc build/smhack20_sd2snes_miniboss.sfc website/ClientApp/src/files/saveStatePatchMiniboss.ips
   displayName: Create IPS patches and move to build directory
 
 - script: |

--- a/build.bat
+++ b/build.bat
@@ -8,6 +8,8 @@ cp resources/sm_orig.sfc build/smhack20_gtclassic.sfc && cd src && ..\tools\asar
 
 cp resources/sm_orig.sfc build/smhack20_14ice.sfc && cd src && ..\tools\asar --no-title-check -DFEATURE_SD2SNES=0 -DCATEGORY=4 main.asm ../build/smhack20_14ice.sfc && cd ..
 
+cp resources/sm_orig.sfc build/smhack20_miniboss.sfc && cd src && ..\tools\asar --no-title-check -DFEATURE_SD2SNES=0 -DCATEGORY=5 main.asm ../build/smhack20_miniboss.sfc && cd ..
+
 cp resources/sm_orig.sfc build/smhack20_sd2snes.sfc && cd src && ..\tools\asar --no-title-check -DFEATURE_SD2SNES=1 -DCATEGORY=0 main.asm ../build/smhack20_sd2snes.sfc && cd ..
 
 cp resources/sm_orig.sfc build/smhack20_sd2snes_rbo.sfc && cd src && ..\tools\asar --no-title-check -DFEATURE_SD2SNES=1 -DCATEGORY=1 main.asm ../build/smhack20_sd2snes_rbo.sfc && cd ..
@@ -17,3 +19,5 @@ cp resources/sm_orig.sfc build/smhack20_sd2snes_kpdr25.sfc && cd src && ..\tools
 cp resources/sm_orig.sfc build/smhack20_sd2snes_gtclassic.sfc && cd src && ..\tools\asar --no-title-check -DFEATURE_SD2SNES=1 -DCATEGORY=3 main.asm ../build/smhack20_sd2snes_gtclassic.sfc && cd ..
 
 cp resources/sm_orig.sfc build/smhack20_sd2snes_14ice.sfc && cd src && ..\tools\asar --no-title-check -DFEATURE_SD2SNES=1 -DCATEGORY=4 main.asm ../build/smhack20_sd2snes_14ice.sfc && cd ..
+
+cp resources/sm_orig.sfc build/smhack20_sd2snes_miniboss.sfc && cd src && ..\tools\asar --no-title-check -DFEATURE_SD2SNES=1 -DCATEGORY=5 main.asm ../build/smhack20_sd2snes_miniboss.sfc && cd ..

--- a/src/defines.asm
+++ b/src/defines.asm
@@ -147,6 +147,7 @@
 !category_kpdr25 = 2
 !category_gtclassic = 3
 !category_14ice = 4
+!category_miniboss = 5
 
 ; ----------
 ; Save/load

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -119,7 +119,7 @@ MainMenu:
     dw #mm_goto_rngmenu
     dw #mm_goto_ctrlsmenu
     dw #$0000
-    %cm_header("SM PRACTICE HACK 2.0.12")
+    %cm_header("SM PRACTICE HACK 2.0.13")
 
 mm_goto_equipment:
     %cm_submenu("Equipment", #EquipmentMenu)

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -95,6 +95,10 @@ preset_category_submenus:
         dw #PresetsMenuGtclassic
     elseif !CATEGORY == !category_14ice
         dw #PresetsMenu14ice
+    elseif !CATEGORY == !category_miniboss
+        dw #PresetsMenuSsrta
+        dw #PresetsMenuCrocrta
+        dw #PresetsMenuGtrta
     else
         error "Unsupported category"
     endif
@@ -160,6 +164,10 @@ elseif !CATEGORY == !category_gtclassic
     incsrc presets/gtclassic_menu.asm
 elseif !CATEGORY == !category_14ice
     incsrc presets/14ice_menu.asm
+elseif !CATEGORY == !category_miniboss
+    incsrc presets/ssrta_menu.asm
+    incsrc presets/crocrta_menu.asm
+    incsrc presets/gtrta_menu.asm
 else
     error "Unsupported category"
 endif
@@ -619,6 +627,10 @@ misc_preset_cateory:
         db #$28, "y GTCLASSIC", #$FF
     elseif !CATEGORY == !category_14ice
         db #$28, "y    14 ICE", #$FF
+    elseif !CATEGORY == !category_miniboss
+        db #$28, "y    SS RTA", #$FF
+        db #$28, "y  CROC RTA", #$FF
+        db #$28, "y    GT RTA", #$FF
     else
         error "Unsupported category"
     endif

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -177,6 +177,10 @@ preset_banks:
         dw preset_gtclassic_crateria_ceres_elevator>>16
     elseif !CATEGORY == !category_14ice
         dw preset_14ice_crateria_ceres_elevator>>16
+    elseif !CATEGORY == !category_miniboss
+        dw preset_ssrta_zebes_asleep_parlor>>16
+        dw preset_crocrta_zebes_asleep_parlor>>16
+        dw preset_gtrta_crateria_parlor>>16
     else
         error "Unsupported category"
     endif
@@ -292,6 +296,21 @@ elseif !CATEGORY == !category_14ice
     print pc, " 14ice data start"
     incsrc presets/14ice_data.asm
     print pc, " 14ice data end"
+elseif !CATEGORY == !category_miniboss
+    org $CEC000  ; 0D18 (length in hex)
+    print pc, " ssrta data start"
+    incsrc presets/ssrta_data.asm
+    print pc, " ssrta data end"
+
+    org $CED000  ; 0DA6 (length in hex)
+    print pc, " crocrta data start"
+    incsrc presets/crocrta_data.asm
+    print pc, " crocrta data end"
+
+    org $CEE000  ; 135C (length in hex)
+    print pc, " gtrta data start"
+    incsrc presets/gtrta_data.asm
+    print pc, " gtrta data end"
 else
     error "Unsupported category"
 endif

--- a/src/presets/crocrta_data.asm
+++ b/src/presets/crocrta_data.asm
@@ -1,0 +1,704 @@
+
+preset_crocrta_zebes_asleep_parlor:
+    dw #$0000
+    dl $7E078B : db $02 : dw $0000 ; Elevator Index
+    dl $7E078D : db $02 : dw $896A ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E079B : db $02 : dw $91F8 ; MDB
+    dl $7E079F : db $02 : dw $0000 ; Region
+    dl $7E07C3 : db $02 : dw $C629 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $7CBA ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2AD ; GFX Pointers
+    dl $7E07F3 : db $02 : dw $0006 ; Music Bank
+    dl $7E07F5 : db $02 : dw $0005 ; Music Track
+    dl $7E090F : db $02 : dw $D000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $1400 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0400 ; Screen Y position in pixels
+    dl $7E093F : db $02 : dw $0000 ; Ceres escape flag
+    dl $7E09A2 : db $02 : dw $0000 ; Equipped Items
+    dl $7E09A4 : db $02 : dw $0000 ; Collected Items
+    dl $7E09A6 : db $02 : dw $0000 ; Beams
+    dl $7E09A8 : db $02 : dw $0000 ; Beams
+    dl $7E09C0 : db $02 : dw $0000 ; Manual/Auto reserve tank
+    dl $7E09C2 : db $02 : dw $0063 ; Health
+    dl $7E09C4 : db $02 : dw $0063 ; Max helath
+    dl $7E09C6 : db $02 : dw $0000 ; Missiles
+    dl $7E09C8 : db $02 : dw $0000 ; Max missiles
+    dl $7E09CA : db $02 : dw $0000 ; Supers
+    dl $7E09CC : db $02 : dw $0000 ; Max supers
+    dl $7E09CE : db $02 : dw $0000 ; Pbs
+    dl $7E09D0 : db $02 : dw $0000 ; Max pbs
+    dl $7E09D4 : db $02 : dw $0000 ; Max reserves
+    dl $7E09D6 : db $02 : dw $0000 ; Reserves
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0A68 : db $02 : dw $0000 ; Flash suit
+    dl $7E0A76 : db $02 : dw $0000 ; Hyper beam
+    dl $7E0AF6 : db $02 : dw $006F ; Samus X
+    dl $7E0AFA : db $02 : dw $049B ; Samus Y
+    dl $7E0B3F : db $02 : dw $0000 ; Blue suit
+    dl $7ED7C0 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7C2 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7C4 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7C6 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7C8 : db $02 : dw $0800 ; SRAM copy
+    dl $7ED7CA : db $02 : dw $0400 ; SRAM copy
+    dl $7ED7CC : db $02 : dw $0200 ; SRAM copy
+    dl $7ED7CE : db $02 : dw $0100 ; SRAM copy
+    dl $7ED7D0 : db $02 : dw $4000 ; SRAM copy
+    dl $7ED7D2 : db $02 : dw $0080 ; SRAM copy
+    dl $7ED7D4 : db $02 : dw $8000 ; SRAM copy
+    dl $7ED7D6 : db $02 : dw $0040 ; SRAM copy
+    dl $7ED7D8 : db $02 : dw $2000 ; SRAM copy
+    dl $7ED7DA : db $02 : dw $0020 ; SRAM copy
+    dl $7ED7DC : db $02 : dw $0010 ; SRAM copy
+    dl $7ED7DE : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7E0 : db $02 : dw $0063 ; SRAM copy
+    dl $7ED7E2 : db $02 : dw $0063 ; SRAM copy
+    dl $7ED7E4 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7E6 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7E8 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7EA : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7EC : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7EE : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7F0 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7F2 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7F4 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7F6 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7F8 : db $02 : dw $0030 ; SRAM copy
+    dl $7ED7FA : db $02 : dw $0006 ; SRAM copy
+    dl $7ED7FC : db $02 : dw $0001 ; SRAM copy
+    dl $7ED7FE : db $02 : dw $0000 ; SRAM copy
+    dl $7ED800 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED802 : db $02 : dw $0001 ; SRAM copy
+    dl $7ED804 : db $02 : dw $0001 ; SRAM copy
+    dl $7ED806 : db $02 : dw $0001 ; SRAM copy
+    dl $7ED808 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED80A : db $02 : dw $0000 ; SRAM copy
+    dl $7ED80C : db $02 : dw $0000 ; SRAM copy
+    dl $7ED80E : db $02 : dw $0000 ; SRAM copy
+    dl $7ED810 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED812 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED814 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED816 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED818 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED81A : db $02 : dw $0000 ; SRAM copy
+    dl $7ED81C : db $02 : dw $0000 ; SRAM copy
+    dl $7ED81E : db $02 : dw $0000 ; SRAM copy
+    dl $7ED820 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED822 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED824 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED826 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED828 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED82A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED82C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED82E : db $02 : dw $0001 ; Events, Items, Doors
+    dl $7ED830 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED832 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED834 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED836 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED838 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED83A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED83C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED83E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED840 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED842 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED844 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED846 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED848 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED84A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED84C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED84E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED850 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED852 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED854 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED856 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED858 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED85A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED85C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED85E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED860 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED862 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED864 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED866 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED868 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED86A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED86C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED86E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED870 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED872 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED874 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED876 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED878 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED87A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED87C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED87E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED880 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED882 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED884 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED886 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED888 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED88A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED88C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED88E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED890 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED892 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED894 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED896 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED898 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED89A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED89C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED89E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8A0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8A2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8A4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8A6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8A8 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8AA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8AC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8AE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8B0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8B2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8B4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8B6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8B8 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8BA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8BC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8BE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8C0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8C2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8C4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8C6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8C8 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8CA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8CC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8CE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8D0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8D2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8D4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8D6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8D8 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8DA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8DC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8DE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8E0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8E2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8E4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8E6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8E8 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8EA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8EC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8EE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8F0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8F2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8F4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8F6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8F8 : db $02 : dw $0001 ; Events, Items, Doors
+    dl $7ED8FA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8FC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8FE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED900 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED902 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED904 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED906 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED908 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED90A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED90C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED90E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED910 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED912 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED914 : db $02 : dw $0005 ; Events, Items, Doors
+    dl $7ED916 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED918 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED91C : db $02 : dw $1010 ; Events, Items, Doors
+    dl $7ED91E : db $02 : dw $0000 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_zebes_asleep_climb_down:
+    dw #preset_crocrta_zebes_asleep_parlor ; Zebes Asleep: Parlor
+    dl $7E078D : db $02 : dw $8916 ; DDB
+    dl $7E079B : db $02 : dw $92FD ; MDB
+    dl $7E090F : db $02 : dw $2FFF ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0100 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $6000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $041F ; Screen Y position in pixels
+    dl $7E0AF6 : db $02 : dw $01A8 ; Samus X
+    dl $7E0AFA : db $02 : dw $04BB ; Samus Y
+    dw #$FFFF
+.after
+
+preset_crocrta_zebes_asleep_pit_room:
+    dw #preset_crocrta_zebes_asleep_climb_down ; Zebes Asleep: Climb Down
+    dl $7E078D : db $02 : dw $898E ; DDB
+    dl $7E078F : db $02 : dw $0004 ; DoorOut Index
+    dl $7E079B : db $02 : dw $96BA ; MDB
+    dl $7E07C3 : db $02 : dw $F911 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $15BA ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B0 ; GFX Pointers
+    dl $7E090F : db $02 : dw $4000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $5400 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0800 ; Screen Y position in pixels
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $01DB ; Samus X
+    dl $7E0AFA : db $02 : dw $088B ; Samus Y
+    dw #$FFFF
+.after
+
+preset_crocrta_zebes_asleep_morph:
+    dw #preset_crocrta_zebes_asleep_pit_room ; Zebes Asleep: Pit Room
+    dl $7E078D : db $02 : dw $8B9E ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9E9F ; MDB
+    dl $7E079F : db $02 : dw $0001 ; Region
+    dl $7E07C3 : db $02 : dw $E6B0 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $64BB ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B2 ; GFX Pointers
+    dl $7E07F5 : db $02 : dw $0007 ; Music Track
+    dl $7E090F : db $02 : dw $6000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0500 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0200 ; Screen Y position in pixels
+    dl $7E0A1C : db $02 : dw $0000 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0000 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0580 ; Samus X
+    dl $7E0AFA : db $02 : dw $02A8 ; Samus Y
+    dl $7ED91A : db $02 : dw $0001 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_zebes_asleep_construction_zone:
+    dw #preset_crocrta_zebes_asleep_morph ; Zebes Asleep: Morph
+    dl $7E078F : db $02 : dw $0003 ; DoorOut Index
+    dl $7E090F : db $02 : dw $2000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0700 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $5000 ; Screen subpixel Y position
+    dl $7E09A2 : db $02 : dw $0004 ; Equipped Items
+    dl $7E09A4 : db $02 : dw $0004 ; Collected Items
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $07A2 ; Samus X
+    dl $7E0AFA : db $02 : dw $028B ; Samus Y
+    dl $7ED872 : db $02 : dw $0400 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_zebes_asleep_construction_zone_revisit:
+    dw #preset_crocrta_zebes_asleep_construction_zone ; Zebes Asleep: Construction Zone
+    dl $7E078D : db $02 : dw $8EDA ; DDB
+    dl $7E078F : db $02 : dw $0002 ; DoorOut Index
+    dl $7E079B : db $02 : dw $A107 ; MDB
+    dl $7E090F : db $02 : dw $0000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $9000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0005 ; Missiles
+    dl $7E09C8 : db $02 : dw $0005 ; Max missiles
+    dl $7E0AF6 : db $02 : dw $0055 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED874 : db $02 : dw $0004 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0002 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_zebes_awake_pit_room_revisit:
+    dw #preset_crocrta_zebes_asleep_construction_zone_revisit ; Zebes Asleep: Construction Zone Revisit
+    dl $7E078D : db $02 : dw $8EB6 ; DDB
+    dl $7E079B : db $02 : dw $97B5 ; MDB
+    dl $7E079F : db $02 : dw $0000 ; Region
+    dl $7E07C3 : db $02 : dw $F911 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $43BA ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2AF ; GFX Pointers
+    dl $7E07F5 : db $02 : dw $0003 ; Music Track
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0A1C : db $02 : dw $0000 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0000 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0080 ; Samus X
+    dl $7E0AFA : db $02 : dw $0088 ; Samus Y
+    dl $7ED91A : db $02 : dw $0003 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_zebes_awake_climb_up:
+    dw #preset_crocrta_zebes_awake_pit_room_revisit ; Zebes Awake: Pit Room Revisit
+    dl $7E078D : db $02 : dw $8B92 ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E079B : db $02 : dw $975C ; MDB
+    dl $7E07F3 : db $02 : dw $0009 ; Music Bank
+    dl $7E07F5 : db $02 : dw $0005 ; Music Track
+    dl $7E090F : db $02 : dw $F000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $4400 ; Screen subpixel Y position
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0088 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED820 : db $02 : dw $0001 ; Events, Items, Doors
+    dl $7ED8B2 : db $02 : dw $0400 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0004 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_zebes_awake_parlor_revisit:
+    dw #preset_crocrta_zebes_awake_climb_up ; Zebes Awake: Climb Up
+    dl $7E078D : db $02 : dw $8B7A ; DDB
+    dl $7E079B : db $02 : dw $96BA ; MDB
+    dl $7E090F : db $02 : dw $2000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0100 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $C000 ; Screen subpixel Y position
+    dl $7E0AF6 : db $02 : dw $0196 ; Samus X
+    dl $7E0AFA : db $02 : dw $005B ; Samus Y
+    dw #$FFFF
+.after
+
+preset_crocrta_zebes_awake_bomb_torizo:
+    dw #preset_crocrta_zebes_awake_parlor_revisit ; Zebes Awake: Parlor Revisit
+    dl $7E078D : db $02 : dw $8982 ; DDB
+    dl $7E078F : db $02 : dw $0003 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9879 ; MDB
+    dl $7E090F : db $02 : dw $0000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0200 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $AC00 ; Screen subpixel Y position
+    dl $7E09C6 : db $02 : dw $0000 ; Missiles
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $02C6 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED8B2 : db $02 : dw $2400 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_zebes_awake_alcatraz:
+    dw #preset_crocrta_zebes_awake_bomb_torizo ; Zebes Awake: Bomb Torizo
+    dl $7E078D : db $02 : dw $8BAA ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E090F : db $02 : dw $2001 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $C000 ; Screen subpixel Y position
+    dl $7E09A2 : db $02 : dw $1004 ; Equipped Items
+    dl $7E09A4 : db $02 : dw $1004 ; Collected Items
+    dl $7E09C6 : db $02 : dw $0005 ; Missiles
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0AF6 : db $02 : dw $003E ; Samus X
+    dl $7ED828 : db $02 : dw $0004 ; Events, Items, Doors
+    dl $7ED870 : db $02 : dw $0080 ; Events, Items, Doors
+    dl $7ED8B2 : db $02 : dw $2C00 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0005 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_zebes_awake_terminator:
+    dw #preset_crocrta_zebes_awake_alcatraz ; Zebes Awake: Alcatraz
+    dl $7E078D : db $02 : dw $8BB6 ; DDB
+    dl $7E079B : db $02 : dw $92FD ; MDB
+    dl $7E07C3 : db $02 : dw $C629 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $7CBA ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2AD ; GFX Pointers
+    dl $7E090F : db $02 : dw $6C00 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0100 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $7BFF ; Screen subpixel Y position
+    dl $7E0A1C : db $02 : dw $0041 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0404 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0115 ; Samus X
+    dl $7E0AFA : db $02 : dw $0099 ; Samus Y
+    dw #$FFFF
+.after
+
+preset_crocrta_zebes_awake_green_pirate_shaft:
+    dw #preset_crocrta_zebes_awake_terminator ; Zebes Awake: Terminator
+    dl $7E078D : db $02 : dw $895E ; DDB
+    dl $7E079B : db $02 : dw $990D ; MDB
+    dl $7E07C3 : db $02 : dw $F911 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $43BA ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2AF ; GFX Pointers
+    dl $7E090F : db $02 : dw $C000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $01FB ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $00C7 ; Health
+    dl $7E09C4 : db $02 : dw $00C7 ; Max helath
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0071 ; Samus X
+    dl $7E0AFA : db $02 : dw $029B ; Samus Y
+    dl $7ED870 : db $02 : dw $0180 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0006 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_brinstar_green_brinstar_elevator:
+    dw #preset_crocrta_zebes_awake_green_pirate_shaft ; Zebes Awake: Green Pirate Shaft
+    dl $7E078D : db $02 : dw $8C22 ; DDB
+    dl $7E078F : db $02 : dw $0002 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9938 ; MDB
+    dl $7E07F5 : db $02 : dw $0003 ; Music Track
+    dl $7E090F : db $02 : dw $0000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $A800 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0002 ; Missiles
+    dl $7E0AF6 : db $02 : dw $0085 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED91A : db $02 : dw $0008 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_brinstar_early_supers:
+    dw #preset_crocrta_brinstar_green_brinstar_elevator ; Brinstar: Green Brinstar Elevator
+    dl $7E078D : db $02 : dw $8C0A ; DDB
+    dl $7E078F : db $02 : dw $0009 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9AD9 ; MDB
+    dl $7E079F : db $02 : dw $0001 ; Region
+    dl $7E07C3 : db $02 : dw $E6B0 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $64BB ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B2 ; GFX Pointers
+    dl $7E07F3 : db $02 : dw $000F ; Music Bank
+    dl $7E07F5 : db $02 : dw $0005 ; Music Track
+    dl $7E090F : db $02 : dw $8000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $041C ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0000 ; Missiles
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $00A4 ; Samus X
+    dl $7E0AFA : db $02 : dw $048B ; Samus Y
+    dl $7ED8B4 : db $02 : dw $0002 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0009 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_brinstar_dachora_room:
+    dw #preset_crocrta_brinstar_early_supers ; Brinstar: Early Supers
+    dl $7E078D : db $02 : dw $8D4E ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E090F : db $02 : dw $7000 ; Screen subpixel X position.
+    dl $7E0915 : db $02 : dw $061A ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $00BD ; Health
+    dl $7E09CA : db $02 : dw $0004 ; Supers
+    dl $7E09CC : db $02 : dw $0005 ; Max supers
+    dl $7E0AF6 : db $02 : dw $0054 ; Samus X
+    dl $7E0AFA : db $02 : dw $068B ; Samus Y
+    dl $7ED872 : db $02 : dw $0401 ; Events, Items, Doors
+    dl $7ED8B4 : db $02 : dw $0006 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $000C ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_brinstar_big_pink:
+    dw #preset_crocrta_brinstar_dachora_room ; Brinstar: Dachora Room
+    dl $7E078D : db $02 : dw $8CE2 ; DDB
+    dl $7E078F : db $02 : dw $0005 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9CB3 ; MDB
+    dl $7E090F : db $02 : dw $2000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0600 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $6800 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $00C7 ; Health
+    dl $7E0AF6 : db $02 : dw $06A6 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dw #$FFFF
+.after
+
+preset_crocrta_brinstar_green_hill_zone:
+    dw #preset_crocrta_brinstar_big_pink ; Brinstar: Big Pink
+    dl $7E078D : db $02 : dw $8DAE ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9D19 ; MDB
+    dl $7E090F : db $02 : dw $4000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0300 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $DBFF ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $05FA ; Screen Y position in pixels
+    dl $7E09A6 : db $02 : dw $1000 ; Beams
+    dl $7E09A8 : db $02 : dw $1000 ; Beams
+    dl $7E09C6 : db $02 : dw $0002 ; Missiles
+    dl $7E09CA : db $02 : dw $0003 ; Supers
+    dl $7E0AF6 : db $02 : dw $0363 ; Samus X
+    dl $7E0AFA : db $02 : dw $068B ; Samus Y
+    dl $7ED872 : db $02 : dw $0481 ; Events, Items, Doors
+    dl $7ED8B4 : db $02 : dw $0206 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $000F ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_brinstar_red_tower:
+    dw #preset_crocrta_brinstar_green_hill_zone ; Brinstar: Green Hill Zone
+    dl $7E078D : db $02 : dw $8E92 ; DDB
+    dl $7E078F : db $02 : dw $0002 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9FBA ; MDB
+    dl $7E090F : db $02 : dw $7000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0500 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0004 ; Missiles
+    dl $7E09CA : db $02 : dw $0004 ; Supers
+    dl $7E0A1C : db $02 : dw $001D ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0408 ; More position/state
+    dl $7E0AF6 : db $02 : dw $05BF ; Samus X
+    dl $7E0AFA : db $02 : dw $0099 ; Samus Y
+    dl $7ED8B6 : db $02 : dw $0008 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0010 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_brinstar_skree_boost:
+    dw #preset_crocrta_brinstar_red_tower ; Brinstar: Red Tower
+    dl $7E078D : db $02 : dw $8F0A ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $A253 ; MDB
+    dl $7E07C3 : db $02 : dw $A5AA ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $5FBC ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B3 ; GFX Pointers
+    dl $7E07F3 : db $02 : dw $0012 ; Music Bank
+    dl $7E090F : db $02 : dw $4000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0915 : db $02 : dw $091A ; Screen Y position in pixels
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0062 ; Samus X
+    dl $7E0AFA : db $02 : dw $098B ; Samus Y
+    dw #$FFFF
+.after
+
+preset_crocrta_norfair_business_center:
+    dw #preset_crocrta_brinstar_skree_boost ; Brinstar: Skree Boost
+    dl $7E078D : db $02 : dw $9246 ; DDB
+    dl $7E078F : db $02 : dw $0002 ; DoorOut Index
+    dl $7E079B : db $02 : dw $A7DE ; MDB
+    dl $7E079F : db $02 : dw $0002 ; Region
+    dl $7E07C3 : db $02 : dw $C3F9 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $BBBD ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B6 ; GFX Pointers
+    dl $7E07F3 : db $02 : dw $0015 ; Music Bank
+    dl $7E090F : db $02 : dw $9000 ; Screen subpixel X position.
+    dl $7E0915 : db $02 : dw $0238 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0003 ; Missiles
+    dl $7E09CA : db $02 : dw $0005 ; Supers
+    dl $7E0A1C : db $02 : dw $0000 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0000 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0080 ; Samus X
+    dl $7E0AFA : db $02 : dw $02A8 ; Samus Y
+    dw #$FFFF
+.after
+
+preset_crocrta_norfair_hi_jump_etank:
+    dw #preset_crocrta_norfair_business_center ; Norfair: Business Center
+    dl $7E078F : db $02 : dw $0005 ; DoorOut Index
+    dl $7E090F : db $02 : dw $F000 ; Screen subpixel X position.
+    dl $7E0915 : db $02 : dw $051B ; Screen Y position in pixels
+    dl $7E09CA : db $02 : dw $0004 ; Supers
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0AF6 : db $02 : dw $003B ; Samus X
+    dl $7E0AFA : db $02 : dw $058B ; Samus Y
+    dl $7ED8B8 : db $02 : dw $2000 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_norfair_business_center_revisit:
+    dw #preset_crocrta_norfair_hi_jump_etank ; Norfair: Hi Jump E-tank
+    dl $7E078D : db $02 : dw $92D6 ; DDB
+    dl $7E078F : db $02 : dw $0002 ; DoorOut Index
+    dl $7E079B : db $02 : dw $AA41 ; MDB
+    dl $7E090F : db $02 : dw $2000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0100 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $2800 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $012B ; Health
+    dl $7E09C4 : db $02 : dw $012B ; Max helath
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0195 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED876 : db $02 : dw $0100 ; Events, Items, Doors
+    dl $7ED8BA : db $02 : dw $0001 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0012 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_norfair_hell_run:
+    dw #preset_crocrta_norfair_business_center_revisit ; Norfair: Business Center Revisit
+    dl $7E078D : db $02 : dw $941A ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E079B : db $02 : dw $A7DE ; MDB
+    dl $7E090F : db $02 : dw $3FFF ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $0800 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0303 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0005 ; Missiles
+    dl $7E0AF6 : db $02 : dw $00A7 ; Samus X
+    dl $7E0AFA : db $02 : dw $038B ; Samus Y
+    dw #$FFFF
+.after
+
+preset_crocrta_norfair_bubble_mountain:
+    dw #preset_crocrta_norfair_hell_run ; Norfair: Hell Run
+    dl $7E078D : db $02 : dw $929A ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $AFA3 ; MDB
+    dl $7E07C5 : db $02 : dw $E4BD ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B5 ; GFX Pointers
+    dl $7E090F : db $02 : dw $8000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0400 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $4400 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $0020 ; Health
+    dl $7E09C6 : db $02 : dw $0001 ; Missiles
+    dl $7E09CA : db $02 : dw $0002 ; Supers
+    dl $7E0AF6 : db $02 : dw $04B5 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED8B8 : db $02 : dw $2600 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0013 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_norfair_farm_room:
+    dw #preset_crocrta_norfair_bubble_mountain ; Norfair: Bubble Mountain
+    dl $7E078D : db $02 : dw $973E ; DDB
+    dl $7E079B : db $02 : dw $ACB3 ; MDB
+    dl $7E090F : db $02 : dw $9000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $F400 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $02FD ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $0042 ; Health
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0055 ; Samus X
+    dl $7E0AFA : db $02 : dw $038B ; Samus Y
+    dl $7ED91A : db $02 : dw $0014 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_crocrta_norfair_acid_snakes_room:
+    dw #preset_crocrta_norfair_farm_room ; Norfair: Farm Room
+    dl $7E078D : db $02 : dw $9726 ; DDB
+    dl $7E078F : db $02 : dw $0002 ; DoorOut Index
+    dl $7E079B : db $02 : dw $B139 ; MDB
+    dl $7E090F : db $02 : dw $0000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $9C00 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $021F ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $0088 ; Health
+    dl $7E09C6 : db $02 : dw $0005 ; Missiles
+    dl $7E09CA : db $02 : dw $0005 ; Supers
+    dl $7E0AF6 : db $02 : dw $00A6 ; Samus X
+    dl $7E0AFA : db $02 : dw $02BB ; Samus Y
+    dw #$FFFF
+.after
+
+preset_crocrta_norfair_crocomire:
+    dw #preset_crocrta_norfair_acid_snakes_room ; Norfair: Acid Snakes Room
+    dl $7E078D : db $02 : dw $974A ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E079B : db $02 : dw $A923 ; MDB
+    dl $7E090F : db $02 : dw $2000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0C00 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $F800 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0200 ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $003B ; Health
+    dl $7E09CA : db $02 : dw $0004 ; Supers
+    dl $7E0AF6 : db $02 : dw $0CD1 ; Samus X
+    dl $7E0AFA : db $02 : dw $028B ; Samus Y
+    dl $7ED8B8 : db $02 : dw $6600 ; Events, Items, Doors
+    dw #$FFFF
+.after

--- a/src/presets/crocrta_menu.asm
+++ b/src/presets/crocrta_menu.asm
@@ -1,0 +1,156 @@
+PresetsMenuCrocrta:
+    dw #presets_goto_crocrta_zebes_asleep
+    dw #presets_goto_crocrta_zebes_awake
+    dw #presets_goto_crocrta_brinstar
+    dw #presets_goto_crocrta_norfair
+    dw #$0000
+    %cm_header("PRESETS FOR CROCRTA")
+
+presets_goto_crocrta_zebes_asleep:
+    %cm_submenu("Zebes Asleep", #presets_submenu_crocrta_zebes_asleep)
+
+presets_goto_crocrta_zebes_awake:
+    %cm_submenu("Zebes Awake", #presets_submenu_crocrta_zebes_awake)
+
+presets_goto_crocrta_brinstar:
+    %cm_submenu("Brinstar", #presets_submenu_crocrta_brinstar)
+
+presets_goto_crocrta_norfair:
+    %cm_submenu("Norfair", #presets_submenu_crocrta_norfair)
+
+presets_submenu_crocrta_zebes_asleep:
+    dw #presets_crocrta_zebes_asleep_parlor
+    dw #presets_crocrta_zebes_asleep_climb_down
+    dw #presets_crocrta_zebes_asleep_pit_room
+    dw #presets_crocrta_zebes_asleep_morph
+    dw #presets_crocrta_zebes_asleep_construction_zone
+    dw #presets_crocrta_zebes_asleep_construction_zone_revisit
+    dw #$0000
+    %cm_header("ZEBES ASLEEP")
+
+presets_submenu_crocrta_zebes_awake:
+    dw #presets_crocrta_zebes_awake_pit_room_revisit
+    dw #presets_crocrta_zebes_awake_climb_up
+    dw #presets_crocrta_zebes_awake_parlor_revisit
+    dw #presets_crocrta_zebes_awake_bomb_torizo
+    dw #presets_crocrta_zebes_awake_alcatraz
+    dw #presets_crocrta_zebes_awake_terminator
+    dw #presets_crocrta_zebes_awake_green_pirate_shaft
+    dw #$0000
+    %cm_header("ZEBES AWAKE")
+
+presets_submenu_crocrta_brinstar:
+    dw #presets_crocrta_brinstar_green_brinstar_elevator
+    dw #presets_crocrta_brinstar_early_supers
+    dw #presets_crocrta_brinstar_dachora_room
+    dw #presets_crocrta_brinstar_big_pink
+    dw #presets_crocrta_brinstar_green_hill_zone
+    dw #presets_crocrta_brinstar_red_tower
+    dw #presets_crocrta_brinstar_skree_boost
+    dw #$0000
+    %cm_header("BRINSTAR")
+
+presets_submenu_crocrta_norfair:
+    dw #presets_crocrta_norfair_business_center
+    dw #presets_crocrta_norfair_hi_jump_etank
+    dw #presets_crocrta_norfair_business_center_revisit
+    dw #presets_crocrta_norfair_hell_run
+    dw #presets_crocrta_norfair_bubble_mountain
+    dw #presets_crocrta_norfair_farm_room
+    dw #presets_crocrta_norfair_acid_snakes_room
+    dw #presets_crocrta_norfair_crocomire
+    dw #$0000
+    %cm_header("NORFAIR")
+
+; Zebes Asleep
+presets_crocrta_zebes_asleep_parlor:
+    %cm_preset("Parlor", #preset_crocrta_zebes_asleep_parlor)
+
+presets_crocrta_zebes_asleep_climb_down:
+    %cm_preset("Climb Down", #preset_crocrta_zebes_asleep_climb_down)
+
+presets_crocrta_zebes_asleep_pit_room:
+    %cm_preset("Pit Room", #preset_crocrta_zebes_asleep_pit_room)
+
+presets_crocrta_zebes_asleep_morph:
+    %cm_preset("Morph", #preset_crocrta_zebes_asleep_morph)
+
+presets_crocrta_zebes_asleep_construction_zone:
+    %cm_preset("Construction Zone", #preset_crocrta_zebes_asleep_construction_zone)
+
+presets_crocrta_zebes_asleep_construction_zone_revisit:
+    %cm_preset("Construction Zone Revisit", #preset_crocrta_zebes_asleep_construction_zone_revisit)
+
+
+; Zebes Awake
+presets_crocrta_zebes_awake_pit_room_revisit:
+    %cm_preset("Pit Room Revisit", #preset_crocrta_zebes_awake_pit_room_revisit)
+
+presets_crocrta_zebes_awake_climb_up:
+    %cm_preset("Climb Up", #preset_crocrta_zebes_awake_climb_up)
+
+presets_crocrta_zebes_awake_parlor_revisit:
+    %cm_preset("Parlor Revisit", #preset_crocrta_zebes_awake_parlor_revisit)
+
+presets_crocrta_zebes_awake_bomb_torizo:
+    %cm_preset("Bomb Torizo", #preset_crocrta_zebes_awake_bomb_torizo)
+
+presets_crocrta_zebes_awake_alcatraz:
+    %cm_preset("Alcatraz", #preset_crocrta_zebes_awake_alcatraz)
+
+presets_crocrta_zebes_awake_terminator:
+    %cm_preset("Terminator", #preset_crocrta_zebes_awake_terminator)
+
+presets_crocrta_zebes_awake_green_pirate_shaft:
+    %cm_preset("Green Pirate Shaft", #preset_crocrta_zebes_awake_green_pirate_shaft)
+
+
+; Brinstar
+presets_crocrta_brinstar_green_brinstar_elevator:
+    %cm_preset("Green Brinstar Elevator", #preset_crocrta_brinstar_green_brinstar_elevator)
+
+presets_crocrta_brinstar_early_supers:
+    %cm_preset("Early Supers", #preset_crocrta_brinstar_early_supers)
+
+presets_crocrta_brinstar_dachora_room:
+    %cm_preset("Dachora Room", #preset_crocrta_brinstar_dachora_room)
+
+presets_crocrta_brinstar_big_pink:
+    %cm_preset("Big Pink", #preset_crocrta_brinstar_big_pink)
+
+presets_crocrta_brinstar_green_hill_zone:
+    %cm_preset("Green Hill Zone", #preset_crocrta_brinstar_green_hill_zone)
+
+presets_crocrta_brinstar_red_tower:
+    %cm_preset("Red Tower", #preset_crocrta_brinstar_red_tower)
+
+presets_crocrta_brinstar_skree_boost:
+    %cm_preset("Skree Boost", #preset_crocrta_brinstar_skree_boost)
+
+
+; Norfair
+presets_crocrta_norfair_business_center:
+    %cm_preset("Business Center", #preset_crocrta_norfair_business_center)
+
+presets_crocrta_norfair_hi_jump_etank:
+    %cm_preset("Hi Jump E-tank", #preset_crocrta_norfair_hi_jump_etank)
+
+presets_crocrta_norfair_business_center_revisit:
+    %cm_preset("Business Center Revisit", #preset_crocrta_norfair_business_center_revisit)
+
+presets_crocrta_norfair_hell_run:
+    %cm_preset("Hell Run", #preset_crocrta_norfair_hell_run)
+
+presets_crocrta_norfair_bubble_mountain:
+    %cm_preset("Bubble Mountain", #preset_crocrta_norfair_bubble_mountain)
+
+presets_crocrta_norfair_farm_room:
+    %cm_preset("Farm Room", #preset_crocrta_norfair_farm_room)
+
+presets_crocrta_norfair_acid_snakes_room:
+    %cm_preset("Acid Snakes Room", #preset_crocrta_norfair_acid_snakes_room)
+
+presets_crocrta_norfair_crocomire:
+    %cm_preset("Crocomire", #preset_crocrta_norfair_crocomire)
+
+

--- a/src/presets/gtrta_data.asm
+++ b/src/presets/gtrta_data.asm
@@ -1,0 +1,1016 @@
+
+preset_gtrta_crateria_parlor:
+    dw #$0000
+    dl $7E078B : db $02 : dw $0000 ; Elevator Index
+    dl $7E078D : db $02 : dw $896A ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E079B : db $02 : dw $91F8 ; MDB
+    dl $7E079F : db $02 : dw $0000 ; Region
+    dl $7E07C3 : db $02 : dw $C629 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $7CBA ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2AD ; GFX Pointers
+    dl $7E07F3 : db $02 : dw $0006 ; Music Bank
+    dl $7E07F5 : db $02 : dw $0005 ; Music Track
+    dl $7E090F : db $02 : dw $D000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $1400 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0400 ; Screen Y position in pixels
+    dl $7E093F : db $02 : dw $0000 ; Ceres escape flag
+    dl $7E09A2 : db $02 : dw $0000 ; Equipped Items
+    dl $7E09A4 : db $02 : dw $0000 ; Collected Items
+    dl $7E09A6 : db $02 : dw $0000 ; Beams
+    dl $7E09A8 : db $02 : dw $0000 ; Beams
+    dl $7E09C0 : db $02 : dw $0000 ; Manual/Auto reserve tank
+    dl $7E09C2 : db $02 : dw $0063 ; Health
+    dl $7E09C4 : db $02 : dw $0063 ; Max helath
+    dl $7E09C6 : db $02 : dw $0000 ; Missiles
+    dl $7E09C8 : db $02 : dw $0000 ; Max missiles
+    dl $7E09CA : db $02 : dw $0000 ; Supers
+    dl $7E09CC : db $02 : dw $0000 ; Max supers
+    dl $7E09CE : db $02 : dw $0000 ; Pbs
+    dl $7E09D0 : db $02 : dw $0000 ; Max pbs
+    dl $7E09D4 : db $02 : dw $0000 ; Max reserves
+    dl $7E09D6 : db $02 : dw $0000 ; Reserves
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0A68 : db $02 : dw $0000 ; Flash suit
+    dl $7E0A76 : db $02 : dw $0000 ; Hyper beam
+    dl $7E0AF6 : db $02 : dw $006F ; Samus X
+    dl $7E0AFA : db $02 : dw $049B ; Samus Y
+    dl $7E0B3F : db $02 : dw $0000 ; Blue suit
+    dl $7ED7C0 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7C2 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7C4 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7C6 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7C8 : db $02 : dw $0800 ; SRAM copy
+    dl $7ED7CA : db $02 : dw $0400 ; SRAM copy
+    dl $7ED7CC : db $02 : dw $0200 ; SRAM copy
+    dl $7ED7CE : db $02 : dw $0100 ; SRAM copy
+    dl $7ED7D0 : db $02 : dw $4000 ; SRAM copy
+    dl $7ED7D2 : db $02 : dw $0080 ; SRAM copy
+    dl $7ED7D4 : db $02 : dw $8000 ; SRAM copy
+    dl $7ED7D6 : db $02 : dw $0040 ; SRAM copy
+    dl $7ED7D8 : db $02 : dw $2000 ; SRAM copy
+    dl $7ED7DA : db $02 : dw $0020 ; SRAM copy
+    dl $7ED7DC : db $02 : dw $0010 ; SRAM copy
+    dl $7ED7DE : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7E0 : db $02 : dw $0063 ; SRAM copy
+    dl $7ED7E2 : db $02 : dw $0063 ; SRAM copy
+    dl $7ED7E4 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7E6 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7E8 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7EA : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7EC : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7EE : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7F0 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7F2 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7F4 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7F6 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7F8 : db $02 : dw $0030 ; SRAM copy
+    dl $7ED7FA : db $02 : dw $0006 ; SRAM copy
+    dl $7ED7FC : db $02 : dw $0001 ; SRAM copy
+    dl $7ED7FE : db $02 : dw $0000 ; SRAM copy
+    dl $7ED800 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED802 : db $02 : dw $0001 ; SRAM copy
+    dl $7ED804 : db $02 : dw $0001 ; SRAM copy
+    dl $7ED806 : db $02 : dw $0001 ; SRAM copy
+    dl $7ED808 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED80A : db $02 : dw $0000 ; SRAM copy
+    dl $7ED80C : db $02 : dw $0000 ; SRAM copy
+    dl $7ED80E : db $02 : dw $0000 ; SRAM copy
+    dl $7ED810 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED812 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED814 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED816 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED818 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED81A : db $02 : dw $0000 ; SRAM copy
+    dl $7ED81C : db $02 : dw $0000 ; SRAM copy
+    dl $7ED81E : db $02 : dw $0000 ; SRAM copy
+    dl $7ED820 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED822 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED824 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED826 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED828 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED82A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED82C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED82E : db $02 : dw $0001 ; Events, Items, Doors
+    dl $7ED830 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED832 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED834 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED836 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED838 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED83A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED83C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED83E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED840 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED842 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED844 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED846 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED848 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED84A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED84C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED84E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED850 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED852 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED854 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED856 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED858 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED85A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED85C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED85E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED860 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED862 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED864 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED866 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED868 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED86A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED86C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED86E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED870 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED872 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED874 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED876 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED878 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED87A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED87C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED87E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED880 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED882 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED884 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED886 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED888 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED88A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED88C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED88E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED890 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED892 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED894 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED896 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED898 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED89A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED89C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED89E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8A0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8A2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8A4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8A6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8A8 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8AA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8AC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8AE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8B0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8B2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8B4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8B6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8B8 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8BA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8BC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8BE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8C0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8C2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8C4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8C6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8C8 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8CA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8CC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8CE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8D0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8D2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8D4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8D6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8D8 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8DA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8DC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8DE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8E0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8E2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8E4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8E6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8E8 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8EA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8EC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8EE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8F0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8F2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8F4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8F6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8F8 : db $02 : dw $0001 ; Events, Items, Doors
+    dl $7ED8FA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8FC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8FE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED900 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED902 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED904 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED906 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED908 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED90A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED90C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED90E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED910 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED912 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED914 : db $02 : dw $0005 ; Events, Items, Doors
+    dl $7ED916 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED918 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED91C : db $02 : dw $1010 ; Events, Items, Doors
+    dl $7ED91E : db $02 : dw $0000 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_crateria_climb_down:
+    dw #preset_gtrta_crateria_parlor ; Crateria: Parlor
+    dl $7E078D : db $02 : dw $8916 ; DDB
+    dl $7E079B : db $02 : dw $92FD ; MDB
+    dl $7E090F : db $02 : dw $2FFF ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0100 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $6000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $041F ; Screen Y position in pixels
+    dl $7E0AF6 : db $02 : dw $01A8 ; Samus X
+    dl $7E0AFA : db $02 : dw $04BB ; Samus Y
+    dw #$FFFF
+.after
+
+preset_gtrta_crateria_pit_room:
+    dw #preset_gtrta_crateria_climb_down ; Crateria: Climb Down
+    dl $7E078D : db $02 : dw $898E ; DDB
+    dl $7E078F : db $02 : dw $0004 ; DoorOut Index
+    dl $7E079B : db $02 : dw $96BA ; MDB
+    dl $7E07C3 : db $02 : dw $F911 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $15BA ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B0 ; GFX Pointers
+    dl $7E090F : db $02 : dw $4000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $5400 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0800 ; Screen Y position in pixels
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $01DB ; Samus X
+    dl $7E0AFA : db $02 : dw $088B ; Samus Y
+    dw #$FFFF
+.after
+
+preset_gtrta_crateria_morph:
+    dw #preset_gtrta_crateria_pit_room ; Crateria: Pit Room
+    dl $7E078D : db $02 : dw $8B9E ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9E9F ; MDB
+    dl $7E079F : db $02 : dw $0001 ; Region
+    dl $7E07C3 : db $02 : dw $E6B0 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $64BB ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B2 ; GFX Pointers
+    dl $7E07F5 : db $02 : dw $0007 ; Music Track
+    dl $7E090F : db $02 : dw $6000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0500 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0200 ; Screen Y position in pixels
+    dl $7E0A1C : db $02 : dw $0000 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0000 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0580 ; Samus X
+    dl $7E0AFA : db $02 : dw $02A8 ; Samus Y
+    dl $7ED91A : db $02 : dw $0001 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_crateria_construction_zone:
+    dw #preset_gtrta_crateria_morph ; Crateria: Morph
+    dl $7E078F : db $02 : dw $0003 ; DoorOut Index
+    dl $7E090F : db $02 : dw $2000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0700 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $5000 ; Screen subpixel Y position
+    dl $7E09A2 : db $02 : dw $0004 ; Equipped Items
+    dl $7E09A4 : db $02 : dw $0004 ; Collected Items
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $07A2 ; Samus X
+    dl $7E0AFA : db $02 : dw $028B ; Samus Y
+    dl $7ED872 : db $02 : dw $0400 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_crateria_construction_zone_revisit:
+    dw #preset_gtrta_crateria_construction_zone ; Crateria: Construction Zone
+    dl $7E078D : db $02 : dw $8EDA ; DDB
+    dl $7E078F : db $02 : dw $0002 ; DoorOut Index
+    dl $7E079B : db $02 : dw $A107 ; MDB
+    dl $7E090F : db $02 : dw $0000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $9000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0005 ; Missiles
+    dl $7E09C8 : db $02 : dw $0005 ; Max missiles
+    dl $7E0AF6 : db $02 : dw $0055 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED874 : db $02 : dw $0004 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0002 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_crateria_pit_room_revisit:
+    dw #preset_gtrta_crateria_construction_zone_revisit ; Crateria: Construction Zone Revisit
+    dl $7E078D : db $02 : dw $8EB6 ; DDB
+    dl $7E079B : db $02 : dw $97B5 ; MDB
+    dl $7E079F : db $02 : dw $0000 ; Region
+    dl $7E07C3 : db $02 : dw $F911 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $43BA ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2AF ; GFX Pointers
+    dl $7E07F5 : db $02 : dw $0003 ; Music Track
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0A1C : db $02 : dw $0000 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0000 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0080 ; Samus X
+    dl $7E0AFA : db $02 : dw $0088 ; Samus Y
+    dl $7ED91A : db $02 : dw $0003 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_crateria_climb_up:
+    dw #preset_gtrta_crateria_pit_room_revisit ; Crateria: Pit Room Revisit
+    dl $7E078D : db $02 : dw $8B92 ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E079B : db $02 : dw $975C ; MDB
+    dl $7E07F3 : db $02 : dw $0009 ; Music Bank
+    dl $7E07F5 : db $02 : dw $0005 ; Music Track
+    dl $7E090F : db $02 : dw $F000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $4400 ; Screen subpixel Y position
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0088 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED820 : db $02 : dw $0001 ; Events, Items, Doors
+    dl $7ED8B2 : db $02 : dw $0400 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0004 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_crateria_parlor_revisit:
+    dw #preset_gtrta_crateria_climb_up ; Crateria: Climb Up
+    dl $7E078D : db $02 : dw $8B7A ; DDB
+    dl $7E079B : db $02 : dw $96BA ; MDB
+    dl $7E090F : db $02 : dw $2000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0100 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $C000 ; Screen subpixel Y position
+    dl $7E0AF6 : db $02 : dw $0196 ; Samus X
+    dl $7E0AFA : db $02 : dw $005B ; Samus Y
+    dw #$FFFF
+.after
+
+preset_gtrta_crateria_bomb_torizo:
+    dw #preset_gtrta_crateria_parlor_revisit ; Crateria: Parlor Revisit
+    dl $7E078D : db $02 : dw $8982 ; DDB
+    dl $7E078F : db $02 : dw $0003 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9879 ; MDB
+    dl $7E090F : db $02 : dw $0000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0200 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $AC00 ; Screen subpixel Y position
+    dl $7E09C6 : db $02 : dw $0000 ; Missiles
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $02C6 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED8B2 : db $02 : dw $2400 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_crateria_alcatraz:
+    dw #preset_gtrta_crateria_bomb_torizo ; Crateria: Bomb Torizo
+    dl $7E078D : db $02 : dw $8BAA ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E090F : db $02 : dw $2001 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $C000 ; Screen subpixel Y position
+    dl $7E09A2 : db $02 : dw $1004 ; Equipped Items
+    dl $7E09A4 : db $02 : dw $1004 ; Collected Items
+    dl $7E09C6 : db $02 : dw $0005 ; Missiles
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0AF6 : db $02 : dw $003E ; Samus X
+    dl $7ED828 : db $02 : dw $0004 ; Events, Items, Doors
+    dl $7ED870 : db $02 : dw $0080 ; Events, Items, Doors
+    dl $7ED8B2 : db $02 : dw $2C00 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0005 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_crateria_terminator:
+    dw #preset_gtrta_crateria_alcatraz ; Crateria: Alcatraz
+    dl $7E078D : db $02 : dw $8BB6 ; DDB
+    dl $7E079B : db $02 : dw $92FD ; MDB
+    dl $7E07C3 : db $02 : dw $C629 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $7CBA ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2AD ; GFX Pointers
+    dl $7E090F : db $02 : dw $6C00 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0100 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $7BFF ; Screen subpixel Y position
+    dl $7E0A1C : db $02 : dw $0041 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0404 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0115 ; Samus X
+    dl $7E0AFA : db $02 : dw $0099 ; Samus Y
+    dw #$FFFF
+.after
+
+preset_gtrta_crateria_green_pirate_shaft:
+    dw #preset_gtrta_crateria_terminator ; Crateria: Terminator
+    dl $7E078D : db $02 : dw $895E ; DDB
+    dl $7E079B : db $02 : dw $990D ; MDB
+    dl $7E07C3 : db $02 : dw $F911 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $43BA ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2AF ; GFX Pointers
+    dl $7E090F : db $02 : dw $C000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $01FB ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $00C7 ; Health
+    dl $7E09C4 : db $02 : dw $00C7 ; Max helath
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0071 ; Samus X
+    dl $7E0AFA : db $02 : dw $029B ; Samus Y
+    dl $7ED870 : db $02 : dw $0180 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0006 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_brinstar_green_brinstar_elevator:
+    dw #preset_gtrta_crateria_green_pirate_shaft ; Crateria: Green Pirate Shaft
+    dl $7E078D : db $02 : dw $8C22 ; DDB
+    dl $7E078F : db $02 : dw $0002 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9938 ; MDB
+    dl $7E07F5 : db $02 : dw $0003 ; Music Track
+    dl $7E090F : db $02 : dw $0000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $A800 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0002 ; Missiles
+    dl $7E0AF6 : db $02 : dw $0085 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED91A : db $02 : dw $0008 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_brinstar_early_supers:
+    dw #preset_gtrta_brinstar_green_brinstar_elevator ; Brinstar: Green Brinstar Elevator
+    dl $7E078D : db $02 : dw $8C0A ; DDB
+    dl $7E078F : db $02 : dw $0009 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9AD9 ; MDB
+    dl $7E079F : db $02 : dw $0001 ; Region
+    dl $7E07C3 : db $02 : dw $E6B0 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $64BB ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B2 ; GFX Pointers
+    dl $7E07F3 : db $02 : dw $000F ; Music Bank
+    dl $7E07F5 : db $02 : dw $0005 ; Music Track
+    dl $7E090F : db $02 : dw $8000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $041C ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0000 ; Missiles
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $00A4 ; Samus X
+    dl $7E0AFA : db $02 : dw $048B ; Samus Y
+    dl $7ED8B4 : db $02 : dw $0002 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0009 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_brinstar_dachora_room:
+    dw #preset_gtrta_brinstar_early_supers ; Brinstar: Early Supers
+    dl $7E078D : db $02 : dw $8D4E ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E090F : db $02 : dw $7000 ; Screen subpixel X position.
+    dl $7E0915 : db $02 : dw $061A ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $00BD ; Health
+    dl $7E09CA : db $02 : dw $0004 ; Supers
+    dl $7E09CC : db $02 : dw $0005 ; Max supers
+    dl $7E0AF6 : db $02 : dw $0054 ; Samus X
+    dl $7E0AFA : db $02 : dw $068B ; Samus Y
+    dl $7ED872 : db $02 : dw $0401 ; Events, Items, Doors
+    dl $7ED8B4 : db $02 : dw $0006 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $000C ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_brinstar_big_pink:
+    dw #preset_gtrta_brinstar_dachora_room ; Brinstar: Dachora Room
+    dl $7E078D : db $02 : dw $8CE2 ; DDB
+    dl $7E078F : db $02 : dw $0005 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9CB3 ; MDB
+    dl $7E090F : db $02 : dw $2000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0600 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $6800 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $00C7 ; Health
+    dl $7E0AF6 : db $02 : dw $06A6 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dw #$FFFF
+.after
+
+preset_gtrta_brinstar_green_hill_zone:
+    dw #preset_gtrta_brinstar_big_pink ; Brinstar: Big Pink
+    dl $7E078D : db $02 : dw $8DEA ; DDB
+    dl $7E078F : db $02 : dw $0003 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9E52 ; MDB
+    dl $7E090F : db $02 : dw $0000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0584 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $2C00 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $02F1 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0004 ; Missiles
+    dl $7E09CA : db $02 : dw $0003 ; Supers
+    dl $7E0A1C : db $02 : dw $0051 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0208 ; More position/state
+    dl $7E0AF6 : db $02 : dw $05E4 ; Samus X
+    dl $7E0AFA : db $02 : dw $0379 ; Samus Y
+    dl $7ED8B4 : db $02 : dw $0206 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0010 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_brinstar_red_tower:
+    dw #preset_gtrta_brinstar_green_hill_zone ; Brinstar: Green Hill Zone
+    dl $7E078D : db $02 : dw $8E92 ; DDB
+    dl $7E078F : db $02 : dw $0002 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9FBA ; MDB
+    dl $7E090F : db $02 : dw $1000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0500 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $B000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0003 ; Missiles
+    dl $7E09CA : db $02 : dw $0004 ; Supers
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $05BD ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED8B6 : db $02 : dw $0008 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_brinstar_hellway:
+    dw #preset_gtrta_brinstar_red_tower ; Brinstar: Red Tower
+    dl $7E078D : db $02 : dw $8F0A ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $A253 ; MDB
+    dl $7E07C3 : db $02 : dw $A5AA ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $5FBC ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B3 ; GFX Pointers
+    dl $7E07F3 : db $02 : dw $0012 ; Music Bank
+    dl $7E090F : db $02 : dw $E000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $6400 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $000F ; Screen Y position in pixels
+    dl $7E0AF6 : db $02 : dw $0093 ; Samus X
+    dw #$FFFF
+.after
+
+preset_gtrta_brinstar_leaving_power_bombs:
+    dw #preset_gtrta_brinstar_hellway ; Brinstar: Hellway
+    dl $7E078D : db $02 : dw $9096 ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E079B : db $02 : dw $A3AE ; MDB
+    dl $7E07F5 : db $02 : dw $0003 ; Music Track
+    dl $7E090F : db $02 : dw $4000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0200 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $9400 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $0093 ; Health
+    dl $7E09C6 : db $02 : dw $0005 ; Missiles
+    dl $7E09CA : db $02 : dw $0003 ; Supers
+    dl $7E09CE : db $02 : dw $0005 ; Pbs
+    dl $7E09D0 : db $02 : dw $0005 ; Max pbs
+    dl $7E0A1C : db $02 : dw $0009 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0108 ; More position/state
+    dl $7E0AF6 : db $02 : dw $02CE ; Samus X
+    dl $7ED874 : db $02 : dw $0104 ; Events, Items, Doors
+    dl $7ED8B6 : db $02 : dw $2008 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0012 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_brinstar_skree_boost:
+    dw #preset_gtrta_brinstar_leaving_power_bombs ; Brinstar: Leaving Power Bombs
+    dl $7E078D : db $02 : dw $907E ; DDB
+    dl $7E079B : db $02 : dw $A253 ; MDB
+    dl $7E07F5 : db $02 : dw $0005 ; Music Track
+    dl $7E090F : db $02 : dw $8000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $091A ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $0073 ; Health
+    dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0063 ; Samus X
+    dl $7E0AFA : db $02 : dw $098B ; Samus Y
+    dl $7ED8B6 : db $02 : dw $3008 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_brinstar_entering_kraids_lair:
+    dw #preset_gtrta_brinstar_skree_boost ; Brinstar: Skree Boost
+    dl $7E078D : db $02 : dw $A348 ; DDB
+    dl $7E078F : db $02 : dw $0002 ; DoorOut Index
+    dl $7E079B : db $02 : dw $CF80 ; MDB
+    dl $7E079F : db $02 : dw $0004 ; Region
+    dl $7E07C3 : db $02 : dw $B130 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $3CBE ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B8 ; GFX Pointers
+    dl $7E090F : db $02 : dw $4000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $9800 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0100 ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $006F ; Health
+    dl $7E09C6 : db $02 : dw $0004 ; Missiles
+    dl $7E09CA : db $02 : dw $0004 ; Supers
+    dl $7E0AF6 : db $02 : dw $002E ; Samus X
+    dl $7E0AFA : db $02 : dw $018B ; Samus Y
+    dw #$FFFF
+.after
+
+preset_gtrta_brinstar_baby_kraid_entering:
+    dw #preset_gtrta_brinstar_entering_kraids_lair ; Brinstar: Entering Kraids Lair
+    dl $7E078D : db $02 : dw $9156 ; DDB
+    dl $7E079B : db $02 : dw $A4DA ; MDB
+    dl $7E079F : db $02 : dw $0001 ; Region
+    dl $7E07C3 : db $02 : dw $A5AA ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $5FBC ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B3 ; GFX Pointers
+    dl $7E090F : db $02 : dw $F000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0100 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $2C00 ; Screen subpixel Y position
+    dl $7E09C6 : db $02 : dw $0005 ; Missiles
+    dl $7E09CA : db $02 : dw $0003 ; Supers
+    dl $7E0AF6 : db $02 : dw $016B ; Samus X
+    dl $7ED91A : db $02 : dw $0013 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_brinstar_kraid:
+    dw #preset_gtrta_brinstar_baby_kraid_entering ; Brinstar: Baby Kraid (Entering)
+    dl $7E078D : db $02 : dw $919E ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $A56B ; MDB
+    dl $7E07F3 : db $02 : dw $0027 ; Music Bank
+    dl $7E07F5 : db $02 : dw $0006 ; Music Track
+    dl $7E090F : db $02 : dw $6000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $E800 ; Screen subpixel Y position
+    dl $7E09C2 : db $02 : dw $0059 ; Health
+    dl $7E09C6 : db $02 : dw $0003 ; Missiles
+    dl $7E09CA : db $02 : dw $0004 ; Supers
+    dl $7E0AF6 : db $02 : dw $01C1 ; Samus X
+    dl $7ED8B8 : db $02 : dw $0024 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_brinstar_baby_kraid_exiting:
+    dw #preset_gtrta_brinstar_kraid ; Brinstar: Kraid
+    dl $7E078D : db $02 : dw $91CE ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E07F5 : db $02 : dw $0003 ; Music Track
+    dl $7E090F : db $02 : dw $6001 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $C400 ; Screen subpixel Y position
+    dl $7E09A2 : db $02 : dw $1005 ; Equipped Items
+    dl $7E09A4 : db $02 : dw $1005 ; Collected Items
+    dl $7E09C2 : db $02 : dw $003A ; Health
+    dl $7E09C6 : db $02 : dw $0005 ; Missiles
+    dl $7E09CA : db $02 : dw $0005 ; Supers
+    dl $7E09CE : db $02 : dw $0005 ; Pbs
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0AF6 : db $02 : dw $005C ; Samus X
+    dl $7ED828 : db $02 : dw $0104 ; Events, Items, Doors
+    dl $7ED876 : db $02 : dw $0001 ; Events, Items, Doors
+    dl $7ED8B8 : db $02 : dw $00E4 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0014 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_brinstar_kraid_etank:
+    dw #preset_gtrta_brinstar_baby_kraid_exiting ; Brinstar: Baby Kraid (Exiting)
+    dl $7E078D : db $02 : dw $916E ; DDB
+    dl $7E079B : db $02 : dw $A471 ; MDB
+    dl $7E07F3 : db $02 : dw $0012 ; Music Bank
+    dl $7E07F5 : db $02 : dw $0005 ; Music Track
+    dl $7E090F : db $02 : dw $8000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $9800 ; Screen subpixel Y position
+    dl $7E09C6 : db $02 : dw $0002 ; Missiles
+    dl $7E0AF6 : db $02 : dw $005B ; Samus X
+    dl $7ED8B8 : db $02 : dw $00EC ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0015 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_bootless_upper_norfair_business_center:
+    dw #preset_gtrta_brinstar_kraid_etank ; Brinstar: Kraid E-tank
+    dl $7E078D : db $02 : dw $9246 ; DDB
+    dl $7E078F : db $02 : dw $0002 ; DoorOut Index
+    dl $7E079B : db $02 : dw $A7DE ; MDB
+    dl $7E079F : db $02 : dw $0002 ; Region
+    dl $7E07C3 : db $02 : dw $C3F9 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $BBBD ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B6 ; GFX Pointers
+    dl $7E07F3 : db $02 : dw $0015 ; Music Bank
+    dl $7E090F : db $02 : dw $D000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0238 ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $012B ; Health
+    dl $7E09C4 : db $02 : dw $012B ; Max helath
+    dl $7E09C6 : db $02 : dw $0004 ; Missiles
+    dl $7E09CA : db $02 : dw $0004 ; Supers
+    dl $7E0A1C : db $02 : dw $009B ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0000 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0080 ; Samus X
+    dl $7E0AFA : db $02 : dw $02A8 ; Samus Y
+    dl $7ED874 : db $02 : dw $0904 ; Events, Items, Doors
+    dl $7ED8B8 : db $02 : dw $00EF ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0016 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_bootless_upper_norfair_cathedral:
+    dw #preset_gtrta_bootless_upper_norfair_business_center ; Bootless Upper Norfair: Business Center
+    dl $7E078D : db $02 : dw $92CA ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $A7B3 ; MDB
+    dl $7E07C5 : db $02 : dw $E4BD ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B5 ; GFX Pointers
+    dl $7E090F : db $02 : dw $0000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0200 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $6400 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $001A ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0002 ; Missiles
+    dl $7E09CA : db $02 : dw $0003 ; Supers
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $02A0 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED8B8 : db $02 : dw $04EF ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_bootless_upper_norfair_bubble_mountain:
+    dw #preset_gtrta_bootless_upper_norfair_cathedral ; Bootless Upper Norfair: Cathedral
+    dl $7E078D : db $02 : dw $929A ; DDB
+    dl $7E079B : db $02 : dw $AFA3 ; MDB
+    dl $7E090F : db $02 : dw $4000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0400 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $4C00 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $0121 ; Health
+    dl $7E09C6 : db $02 : dw $0004 ; Missiles
+    dl $7E09CA : db $02 : dw $0002 ; Supers
+    dl $7E0A1C : db $02 : dw $001D ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0408 ; More position/state
+    dl $7E0AF6 : db $02 : dw $04BE ; Samus X
+    dl $7E0AFA : db $02 : dw $0099 ; Samus Y
+    dl $7ED8B8 : db $02 : dw $06EF ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0017 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_bootless_upper_norfair_magdollite_tunnel:
+    dw #preset_gtrta_bootless_upper_norfair_bubble_mountain ; Bootless Upper Norfair: Bubble Mountain
+    dl $7E078D : db $02 : dw $9576 ; DDB
+    dl $7E078F : db $02 : dw $0003 ; DoorOut Index
+    dl $7E079B : db $02 : dw $AEDF ; MDB
+    dl $7E090F : db $02 : dw $6000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $01F2 ; Screen Y position in pixels
+    dl $7E09CA : db $02 : dw $0003 ; Supers
+    dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $005A ; Samus X
+    dl $7E0AFA : db $02 : dw $028B ; Samus Y
+    dl $7ED91A : db $02 : dw $0018 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_bootless_upper_norfair_lava_dive:
+    dw #preset_gtrta_bootless_upper_norfair_magdollite_tunnel ; Bootless Upper Norfair: Magdollite Tunnel
+    dl $7E078D : db $02 : dw $96A2 ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $AE74 ; MDB
+    dl $7E090F : db $02 : dw $4000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0100 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $4800 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0200 ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $012B ; Health
+    dl $7E09C6 : db $02 : dw $0002 ; Missiles
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0155 ; Samus X
+    dl $7ED8BA : db $02 : dw $0100 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_bootless_upper_norfair_ln_main_hall:
+    dw #preset_gtrta_bootless_upper_norfair_lava_dive ; Bootless Upper Norfair: Lava Dive
+    dl $7E078D : db $02 : dw $96F6 ; DDB
+    dl $7E079B : db $02 : dw $B236 ; MDB
+    dl $7E07F3 : db $02 : dw $0018 ; Music Bank
+    dl $7E090F : db $02 : dw $E000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0400 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E09C2 : db $02 : dw $0022 ; Health
+    dl $7E0A1C : db $02 : dw $009B ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0000 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0480 ; Samus X
+    dl $7E0AFA : db $02 : dw $0288 ; Samus Y
+    dw #$FFFF
+.after
+
+preset_gtrta_bootless_upper_norfair_green_gate_glitch:
+    dw #preset_gtrta_bootless_upper_norfair_ln_main_hall ; Bootless Upper Norfair: LN Main Hall
+    dl $7E078D : db $02 : dw $985E ; DDB
+    dl $7E079B : db $02 : dw $B3A5 ; MDB
+    dl $7E090F : db $02 : dw $D000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $4000 ; Screen subpixel Y position
+    dl $7E09CE : db $02 : dw $0005 ; Pbs
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0089 ; Samus X
+    dl $7E0AFA : db $02 : dw $029B ; Samus Y
+    dw #$FFFF
+.after
+
+preset_gtrta_bootless_upper_norfair_golden_torizo:
+    dw #preset_gtrta_bootless_upper_norfair_green_gate_glitch ; Bootless Upper Norfair: Green Gate Glitch
+    dl $7E078D : db $02 : dw $988E ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E079B : db $02 : dw $B6C1 ; MDB
+    dl $7E07F5 : db $02 : dw $0003 ; Music Track
+    dl $7E090F : db $02 : dw $8000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $A000 ; Screen subpixel Y position
+    dl $7E09CA : db $02 : dw $0005 ; Supers
+    dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E0AF6 : db $02 : dw $004A ; Samus X
+    dl $7ED91A : db $02 : dw $0019 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_hi_jump_upper_norfair_business_center:
+    dw #preset_gtrta_brinstar_kraid_etank ; Brinstar: Kraid E-tank
+    dl $7E078D : db $02 : dw $9246 ; DDB
+    dl $7E078F : db $02 : dw $0002 ; DoorOut Index
+    dl $7E079B : db $02 : dw $A7DE ; MDB
+    dl $7E079F : db $02 : dw $0002 ; Region
+    dl $7E07C3 : db $02 : dw $C3F9 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $BBBD ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B6 ; GFX Pointers
+    dl $7E07F3 : db $02 : dw $0015 ; Music Bank
+    dl $7E090F : db $02 : dw $0000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0238 ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $003A ; Health
+    dl $7E09C4 : db $02 : dw $00C7 ; Max helath
+    dl $7E09C6 : db $02 : dw $0004 ; Missiles
+    dl $7E09CA : db $02 : dw $0004 ; Supers
+    dl $7E0A1C : db $02 : dw $009B ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0000 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0080 ; Samus X
+    dl $7E0AFA : db $02 : dw $02A8 ; Samus Y
+    dl $7ED874 : db $02 : dw $0104 ; Events, Items, Doors
+    dl $7ED8B8 : db $02 : dw $00EC ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0015 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_hi_jump_upper_norfair_leaving_hi_jump:
+    dw #preset_gtrta_hi_jump_upper_norfair_business_center ; Hi Jump Upper Norfair: Business Center
+    dl $7E078D : db $02 : dw $9426 ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $A9E5 ; MDB
+    dl $7E07F5 : db $02 : dw $0003 ; Music Track
+    dl $7E090F : db $02 : dw $D000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $6800 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09A2 : db $02 : dw $1105 ; Equipped Items
+    dl $7E09A4 : db $02 : dw $1105 ; Collected Items
+    dl $7E09C2 : db $02 : dw $012B ; Health
+    dl $7E09C4 : db $02 : dw $012B ; Max helath
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0046 ; Samus X
+    dl $7E0AFA : db $02 : dw $00BB ; Samus Y
+    dl $7ED876 : db $02 : dw $0121 ; Events, Items, Doors
+    dl $7ED8B8 : db $02 : dw $20EC ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0018 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_hi_jump_upper_norfair_precathedral:
+    dw #preset_gtrta_hi_jump_upper_norfair_leaving_hi_jump ; Hi Jump Upper Norfair: Leaving Hi Jump
+    dl $7E078D : db $02 : dw $941A ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E079B : db $02 : dw $A7DE ; MDB
+    dl $7E07F5 : db $02 : dw $0005 ; Music Track
+    dl $7E090F : db $02 : dw $5000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $BFFF ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $02F6 ; Screen Y position in pixels
+    dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E0AF6 : db $02 : dw $00AC ; Samus X
+    dl $7E0AFA : db $02 : dw $038B ; Samus Y
+    dl $7ED8BA : db $02 : dw $0001 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $001A ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_hi_jump_upper_norfair_bubble_mountain:
+    dw #preset_gtrta_hi_jump_upper_norfair_precathedral ; Hi Jump Upper Norfair: Pre-Cathedral
+    dl $7E078D : db $02 : dw $929A ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $AFA3 ; MDB
+    dl $7E07C5 : db $02 : dw $E4BD ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B5 ; GFX Pointers
+    dl $7E090F : db $02 : dw $D000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0400 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $CC00 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $0115 ; Health
+    dl $7E09C6 : db $02 : dw $0003 ; Missiles
+    dl $7E09CA : db $02 : dw $0002 ; Supers
+    dl $7E0A1C : db $02 : dw $001D ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0408 ; More position/state
+    dl $7E0AF6 : db $02 : dw $04B2 ; Samus X
+    dl $7E0AFA : db $02 : dw $0099 ; Samus Y
+    dl $7ED8B8 : db $02 : dw $26EC ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $001B ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_hi_jump_upper_norfair_magdollite_tunnel:
+    dw #preset_gtrta_hi_jump_upper_norfair_bubble_mountain ; Hi Jump Upper Norfair: Bubble Mountain
+    dl $7E078D : db $02 : dw $9576 ; DDB
+    dl $7E078F : db $02 : dw $0003 ; DoorOut Index
+    dl $7E079B : db $02 : dw $AEDF ; MDB
+    dl $7E090F : db $02 : dw $B000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $01F3 ; Screen Y position in pixels
+    dl $7E09CE : db $02 : dw $0003 ; Pbs
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $005B ; Samus X
+    dl $7E0AFA : db $02 : dw $028B ; Samus Y
+    dl $7ED91A : db $02 : dw $001C ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_hi_jump_upper_norfair_lava_dive:
+    dw #preset_gtrta_hi_jump_upper_norfair_magdollite_tunnel ; Hi Jump Upper Norfair: Magdollite Tunnel
+    dl $7E078D : db $02 : dw $96A2 ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $AE74 ; MDB
+    dl $7E090F : db $02 : dw $9000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0100 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $6C00 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0200 ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $011F ; Health
+    dl $7E09C6 : db $02 : dw $0001 ; Missiles
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0155 ; Samus X
+    dl $7ED8BA : db $02 : dw $0101 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_gtrta_hi_jump_upper_norfair_ln_main_hall:
+    dw #preset_gtrta_hi_jump_upper_norfair_lava_dive ; Hi Jump Upper Norfair: Lava Dive
+    dl $7E078D : db $02 : dw $96F6 ; DDB
+    dl $7E079B : db $02 : dw $B236 ; MDB
+    dl $7E07F3 : db $02 : dw $0018 ; Music Bank
+    dl $7E090F : db $02 : dw $0000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0400 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E09C2 : db $02 : dw $009D ; Health
+    dl $7E0A1C : db $02 : dw $009B ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0000 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0480 ; Samus X
+    dl $7E0AFA : db $02 : dw $0288 ; Samus Y
+    dw #$FFFF
+.after
+
+preset_gtrta_hi_jump_upper_norfair_green_gate_glitch:
+    dw #preset_gtrta_hi_jump_upper_norfair_ln_main_hall ; Hi Jump Upper Norfair: LN Main Hall
+    dl $7E078D : db $02 : dw $985E ; DDB
+    dl $7E079B : db $02 : dw $B3A5 ; MDB
+    dl $7E090F : db $02 : dw $4000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $4000 ; Screen subpixel Y position
+    dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0AF6 : db $02 : dw $007C ; Samus X
+    dl $7E0AFA : db $02 : dw $029B ; Samus Y
+    dw #$FFFF
+.after
+
+preset_gtrta_hi_jump_upper_norfair_golden_torizo:
+    dw #preset_gtrta_hi_jump_upper_norfair_green_gate_glitch ; Hi Jump Upper Norfair: Green Gate Glitch
+    dl $7E078D : db $02 : dw $988E ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E079B : db $02 : dw $B6C1 ; MDB
+    dl $7E07F5 : db $02 : dw $0003 ; Music Track
+    dl $7E09CA : db $02 : dw $0005 ; Supers
+    dl $7E09CE : db $02 : dw $0003 ; Pbs
+    dl $7E0AF6 : db $02 : dw $0056 ; Samus X
+    dl $7ED91A : db $02 : dw $001D ; Events, Items, Doors
+    dw #$FFFF
+.after

--- a/src/presets/gtrta_menu.asm
+++ b/src/presets/gtrta_menu.asm
@@ -1,0 +1,220 @@
+PresetsMenuGtrta:
+    dw #presets_goto_gtrta_crateria
+    dw #presets_goto_gtrta_brinstar
+    dw #presets_goto_gtrta_bootless_upper_norfair
+    dw #presets_goto_gtrta_hi_jump_upper_norfair
+    dw #$0000
+    %cm_header("PRESETS FOR GTRTA")
+
+presets_goto_gtrta_crateria:
+    %cm_submenu("Crateria", #presets_submenu_gtrta_crateria)
+
+presets_goto_gtrta_brinstar:
+    %cm_submenu("Brinstar", #presets_submenu_gtrta_brinstar)
+
+presets_goto_gtrta_bootless_upper_norfair:
+    %cm_submenu("Bootless Upper Norfair", #presets_submenu_gtrta_bootless_upper_norfair)
+
+presets_goto_gtrta_hi_jump_upper_norfair:
+    %cm_submenu("Hi Jump Upper Norfair", #presets_submenu_gtrta_hi_jump_upper_norfair)
+
+presets_submenu_gtrta_crateria:
+    dw #presets_gtrta_crateria_parlor
+    dw #presets_gtrta_crateria_climb_down
+    dw #presets_gtrta_crateria_pit_room
+    dw #presets_gtrta_crateria_morph
+    dw #presets_gtrta_crateria_construction_zone
+    dw #presets_gtrta_crateria_construction_zone_revisit
+    dw #presets_gtrta_crateria_pit_room_revisit
+    dw #presets_gtrta_crateria_climb_up
+    dw #presets_gtrta_crateria_parlor_revisit
+    dw #presets_gtrta_crateria_bomb_torizo
+    dw #presets_gtrta_crateria_alcatraz
+    dw #presets_gtrta_crateria_terminator
+    dw #presets_gtrta_crateria_green_pirate_shaft
+    dw #$0000
+    %cm_header("CRATERIA")
+
+presets_submenu_gtrta_brinstar:
+    dw #presets_gtrta_brinstar_green_brinstar_elevator
+    dw #presets_gtrta_brinstar_early_supers
+    dw #presets_gtrta_brinstar_dachora_room
+    dw #presets_gtrta_brinstar_big_pink
+    dw #presets_gtrta_brinstar_green_hill_zone
+    dw #presets_gtrta_brinstar_red_tower
+    dw #presets_gtrta_brinstar_hellway
+    dw #presets_gtrta_brinstar_leaving_power_bombs
+    dw #presets_gtrta_brinstar_skree_boost
+    dw #presets_gtrta_brinstar_entering_kraids_lair
+    dw #presets_gtrta_brinstar_baby_kraid_entering
+    dw #presets_gtrta_brinstar_kraid
+    dw #presets_gtrta_brinstar_baby_kraid_exiting
+    dw #presets_gtrta_brinstar_kraid_etank
+    dw #$0000
+    %cm_header("BRINSTAR")
+
+presets_submenu_gtrta_bootless_upper_norfair:
+    dw #presets_gtrta_bootless_upper_norfair_business_center
+    dw #presets_gtrta_bootless_upper_norfair_cathedral
+    dw #presets_gtrta_bootless_upper_norfair_bubble_mountain
+    dw #presets_gtrta_bootless_upper_norfair_magdollite_tunnel
+    dw #presets_gtrta_bootless_upper_norfair_lava_dive
+    dw #presets_gtrta_bootless_upper_norfair_ln_main_hall
+    dw #presets_gtrta_bootless_upper_norfair_green_gate_glitch
+    dw #presets_gtrta_bootless_upper_norfair_golden_torizo
+    dw #$0000
+    %cm_header("BOOTLESS UPPER NORFAIR")
+
+presets_submenu_gtrta_hi_jump_upper_norfair:
+    dw #presets_gtrta_hi_jump_upper_norfair_business_center
+    dw #presets_gtrta_hi_jump_upper_norfair_leaving_hi_jump
+    dw #presets_gtrta_hi_jump_upper_norfair_precathedral
+    dw #presets_gtrta_hi_jump_upper_norfair_bubble_mountain
+    dw #presets_gtrta_hi_jump_upper_norfair_magdollite_tunnel
+    dw #presets_gtrta_hi_jump_upper_norfair_lava_dive
+    dw #presets_gtrta_hi_jump_upper_norfair_ln_main_hall
+    dw #presets_gtrta_hi_jump_upper_norfair_green_gate_glitch
+    dw #presets_gtrta_hi_jump_upper_norfair_golden_torizo
+    dw #$0000
+    %cm_header("HI JUMP UPPER NORFAIR")
+
+; Crateria
+presets_gtrta_crateria_parlor:
+    %cm_preset("Parlor", #preset_gtrta_crateria_parlor)
+
+presets_gtrta_crateria_climb_down:
+    %cm_preset("Climb Down", #preset_gtrta_crateria_climb_down)
+
+presets_gtrta_crateria_pit_room:
+    %cm_preset("Pit Room", #preset_gtrta_crateria_pit_room)
+
+presets_gtrta_crateria_morph:
+    %cm_preset("Morph", #preset_gtrta_crateria_morph)
+
+presets_gtrta_crateria_construction_zone:
+    %cm_preset("Construction Zone", #preset_gtrta_crateria_construction_zone)
+
+presets_gtrta_crateria_construction_zone_revisit:
+    %cm_preset("Construction Zone Revisit", #preset_gtrta_crateria_construction_zone_revisit)
+
+presets_gtrta_crateria_pit_room_revisit:
+    %cm_preset("Pit Room Revisit", #preset_gtrta_crateria_pit_room_revisit)
+
+presets_gtrta_crateria_climb_up:
+    %cm_preset("Climb Up", #preset_gtrta_crateria_climb_up)
+
+presets_gtrta_crateria_parlor_revisit:
+    %cm_preset("Parlor Revisit", #preset_gtrta_crateria_parlor_revisit)
+
+presets_gtrta_crateria_bomb_torizo:
+    %cm_preset("Bomb Torizo", #preset_gtrta_crateria_bomb_torizo)
+
+presets_gtrta_crateria_alcatraz:
+    %cm_preset("Alcatraz", #preset_gtrta_crateria_alcatraz)
+
+presets_gtrta_crateria_terminator:
+    %cm_preset("Terminator", #preset_gtrta_crateria_terminator)
+
+presets_gtrta_crateria_green_pirate_shaft:
+    %cm_preset("Green Pirate Shaft", #preset_gtrta_crateria_green_pirate_shaft)
+
+
+; Brinstar
+presets_gtrta_brinstar_green_brinstar_elevator:
+    %cm_preset("Green Brinstar Elevator", #preset_gtrta_brinstar_green_brinstar_elevator)
+
+presets_gtrta_brinstar_early_supers:
+    %cm_preset("Early Supers", #preset_gtrta_brinstar_early_supers)
+
+presets_gtrta_brinstar_dachora_room:
+    %cm_preset("Dachora Room", #preset_gtrta_brinstar_dachora_room)
+
+presets_gtrta_brinstar_big_pink:
+    %cm_preset("Big Pink", #preset_gtrta_brinstar_big_pink)
+
+presets_gtrta_brinstar_green_hill_zone:
+    %cm_preset("Green Hill Zone", #preset_gtrta_brinstar_green_hill_zone)
+
+presets_gtrta_brinstar_red_tower:
+    %cm_preset("Red Tower", #preset_gtrta_brinstar_red_tower)
+
+presets_gtrta_brinstar_hellway:
+    %cm_preset("Hellway", #preset_gtrta_brinstar_hellway)
+
+presets_gtrta_brinstar_leaving_power_bombs:
+    %cm_preset("Leaving Power Bombs", #preset_gtrta_brinstar_leaving_power_bombs)
+
+presets_gtrta_brinstar_skree_boost:
+    %cm_preset("Skree Boost", #preset_gtrta_brinstar_skree_boost)
+
+presets_gtrta_brinstar_entering_kraids_lair:
+    %cm_preset("Entering Kraids Lair", #preset_gtrta_brinstar_entering_kraids_lair)
+
+presets_gtrta_brinstar_baby_kraid_entering:
+    %cm_preset("Baby Kraid (Entering)", #preset_gtrta_brinstar_baby_kraid_entering)
+
+presets_gtrta_brinstar_kraid:
+    %cm_preset("Kraid", #preset_gtrta_brinstar_kraid)
+
+presets_gtrta_brinstar_baby_kraid_exiting:
+    %cm_preset("Baby Kraid (Exiting)", #preset_gtrta_brinstar_baby_kraid_exiting)
+
+presets_gtrta_brinstar_kraid_etank:
+    %cm_preset("Kraid E-tank", #preset_gtrta_brinstar_kraid_etank)
+
+
+; Bootless Upper Norfair
+presets_gtrta_bootless_upper_norfair_business_center:
+    %cm_preset("Business Center", #preset_gtrta_bootless_upper_norfair_business_center)
+
+presets_gtrta_bootless_upper_norfair_cathedral:
+    %cm_preset("Cathedral", #preset_gtrta_bootless_upper_norfair_cathedral)
+
+presets_gtrta_bootless_upper_norfair_bubble_mountain:
+    %cm_preset("Bubble Mountain", #preset_gtrta_bootless_upper_norfair_bubble_mountain)
+
+presets_gtrta_bootless_upper_norfair_magdollite_tunnel:
+    %cm_preset("Magdollite Tunnel", #preset_gtrta_bootless_upper_norfair_magdollite_tunnel)
+
+presets_gtrta_bootless_upper_norfair_lava_dive:
+    %cm_preset("Lava Dive", #preset_gtrta_bootless_upper_norfair_lava_dive)
+
+presets_gtrta_bootless_upper_norfair_ln_main_hall:
+    %cm_preset("LN Main Hall", #preset_gtrta_bootless_upper_norfair_ln_main_hall)
+
+presets_gtrta_bootless_upper_norfair_green_gate_glitch:
+    %cm_preset("Green Gate Glitch", #preset_gtrta_bootless_upper_norfair_green_gate_glitch)
+
+presets_gtrta_bootless_upper_norfair_golden_torizo:
+    %cm_preset("Golden Torizo", #preset_gtrta_bootless_upper_norfair_golden_torizo)
+
+
+; Hi Jump Upper Norfair
+presets_gtrta_hi_jump_upper_norfair_business_center:
+    %cm_preset("Business Center", #preset_gtrta_hi_jump_upper_norfair_business_center)
+
+presets_gtrta_hi_jump_upper_norfair_leaving_hi_jump:
+    %cm_preset("Leaving Hi Jump", #preset_gtrta_hi_jump_upper_norfair_leaving_hi_jump)
+
+presets_gtrta_hi_jump_upper_norfair_precathedral:
+    %cm_preset("Pre-Cathedral", #preset_gtrta_hi_jump_upper_norfair_precathedral)
+
+presets_gtrta_hi_jump_upper_norfair_bubble_mountain:
+    %cm_preset("Bubble Mountain", #preset_gtrta_hi_jump_upper_norfair_bubble_mountain)
+
+presets_gtrta_hi_jump_upper_norfair_magdollite_tunnel:
+    %cm_preset("Magdollite Tunnel", #preset_gtrta_hi_jump_upper_norfair_magdollite_tunnel)
+
+presets_gtrta_hi_jump_upper_norfair_lava_dive:
+    %cm_preset("Lava Dive", #preset_gtrta_hi_jump_upper_norfair_lava_dive)
+
+presets_gtrta_hi_jump_upper_norfair_ln_main_hall:
+    %cm_preset("LN Main Hall", #preset_gtrta_hi_jump_upper_norfair_ln_main_hall)
+
+presets_gtrta_hi_jump_upper_norfair_green_gate_glitch:
+    %cm_preset("Green Gate Glitch", #preset_gtrta_hi_jump_upper_norfair_green_gate_glitch)
+
+presets_gtrta_hi_jump_upper_norfair_golden_torizo:
+    %cm_preset("Golden Torizo", #preset_gtrta_hi_jump_upper_norfair_golden_torizo)
+
+

--- a/src/presets/ssrta_data.asm
+++ b/src/presets/ssrta_data.asm
@@ -1,0 +1,660 @@
+
+preset_ssrta_zebes_asleep_parlor:
+    dw #$0000
+    dl $7E078B : db $02 : dw $0000 ; Elevator Index
+    dl $7E078D : db $02 : dw $896A ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E079B : db $02 : dw $91F8 ; MDB
+    dl $7E079F : db $02 : dw $0000 ; Region
+    dl $7E07C3 : db $02 : dw $C629 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $7CBA ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2AD ; GFX Pointers
+    dl $7E07F3 : db $02 : dw $0006 ; Music Bank
+    dl $7E07F5 : db $02 : dw $0005 ; Music Track
+    dl $7E090F : db $02 : dw $D000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $1400 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0400 ; Screen Y position in pixels
+    dl $7E093F : db $02 : dw $0000 ; Ceres escape flag
+    dl $7E09A2 : db $02 : dw $0000 ; Equipped Items
+    dl $7E09A4 : db $02 : dw $0000 ; Collected Items
+    dl $7E09A6 : db $02 : dw $0000 ; Beams
+    dl $7E09A8 : db $02 : dw $0000 ; Beams
+    dl $7E09C0 : db $02 : dw $0000 ; Manual/Auto reserve tank
+    dl $7E09C2 : db $02 : dw $0063 ; Health
+    dl $7E09C4 : db $02 : dw $0063 ; Max helath
+    dl $7E09C6 : db $02 : dw $0000 ; Missiles
+    dl $7E09C8 : db $02 : dw $0000 ; Max missiles
+    dl $7E09CA : db $02 : dw $0000 ; Supers
+    dl $7E09CC : db $02 : dw $0000 ; Max supers
+    dl $7E09CE : db $02 : dw $0000 ; Pbs
+    dl $7E09D0 : db $02 : dw $0000 ; Max pbs
+    dl $7E09D4 : db $02 : dw $0000 ; Max reserves
+    dl $7E09D6 : db $02 : dw $0000 ; Reserves
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0A68 : db $02 : dw $0000 ; Flash suit
+    dl $7E0A76 : db $02 : dw $0000 ; Hyper beam
+    dl $7E0AF6 : db $02 : dw $006F ; Samus X
+    dl $7E0AFA : db $02 : dw $049B ; Samus Y
+    dl $7E0B3F : db $02 : dw $0000 ; Blue suit
+    dl $7ED7C0 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7C2 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7C4 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7C6 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7C8 : db $02 : dw $0800 ; SRAM copy
+    dl $7ED7CA : db $02 : dw $0400 ; SRAM copy
+    dl $7ED7CC : db $02 : dw $0200 ; SRAM copy
+    dl $7ED7CE : db $02 : dw $0100 ; SRAM copy
+    dl $7ED7D0 : db $02 : dw $4000 ; SRAM copy
+    dl $7ED7D2 : db $02 : dw $0080 ; SRAM copy
+    dl $7ED7D4 : db $02 : dw $8000 ; SRAM copy
+    dl $7ED7D6 : db $02 : dw $0040 ; SRAM copy
+    dl $7ED7D8 : db $02 : dw $2000 ; SRAM copy
+    dl $7ED7DA : db $02 : dw $0020 ; SRAM copy
+    dl $7ED7DC : db $02 : dw $0010 ; SRAM copy
+    dl $7ED7DE : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7E0 : db $02 : dw $0063 ; SRAM copy
+    dl $7ED7E2 : db $02 : dw $0063 ; SRAM copy
+    dl $7ED7E4 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7E6 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7E8 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7EA : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7EC : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7EE : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7F0 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7F2 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7F4 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7F6 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED7F8 : db $02 : dw $0030 ; SRAM copy
+    dl $7ED7FA : db $02 : dw $0006 ; SRAM copy
+    dl $7ED7FC : db $02 : dw $0001 ; SRAM copy
+    dl $7ED7FE : db $02 : dw $0000 ; SRAM copy
+    dl $7ED800 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED802 : db $02 : dw $0001 ; SRAM copy
+    dl $7ED804 : db $02 : dw $0001 ; SRAM copy
+    dl $7ED806 : db $02 : dw $0001 ; SRAM copy
+    dl $7ED808 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED80A : db $02 : dw $0000 ; SRAM copy
+    dl $7ED80C : db $02 : dw $0000 ; SRAM copy
+    dl $7ED80E : db $02 : dw $0000 ; SRAM copy
+    dl $7ED810 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED812 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED814 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED816 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED818 : db $02 : dw $0000 ; SRAM copy
+    dl $7ED81A : db $02 : dw $0000 ; SRAM copy
+    dl $7ED81C : db $02 : dw $0000 ; SRAM copy
+    dl $7ED81E : db $02 : dw $0000 ; SRAM copy
+    dl $7ED820 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED822 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED824 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED826 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED828 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED82A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED82C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED82E : db $02 : dw $0001 ; Events, Items, Doors
+    dl $7ED830 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED832 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED834 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED836 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED838 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED83A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED83C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED83E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED840 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED842 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED844 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED846 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED848 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED84A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED84C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED84E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED850 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED852 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED854 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED856 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED858 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED85A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED85C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED85E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED860 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED862 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED864 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED866 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED868 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED86A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED86C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED86E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED870 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED872 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED874 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED876 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED878 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED87A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED87C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED87E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED880 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED882 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED884 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED886 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED888 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED88A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED88C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED88E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED890 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED892 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED894 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED896 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED898 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED89A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED89C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED89E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8A0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8A2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8A4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8A6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8A8 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8AA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8AC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8AE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8B0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8B2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8B4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8B6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8B8 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8BA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8BC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8BE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8C0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8C2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8C4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8C6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8C8 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8CA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8CC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8CE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8D0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8D2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8D4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8D6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8D8 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8DA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8DC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8DE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8E0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8E2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8E4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8E6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8E8 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8EA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8EC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8EE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8F0 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8F2 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8F4 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8F6 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8F8 : db $02 : dw $0001 ; Events, Items, Doors
+    dl $7ED8FA : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8FC : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED8FE : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED900 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED902 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED904 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED906 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED908 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED90A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED90C : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED90E : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED910 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED912 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED914 : db $02 : dw $0005 ; Events, Items, Doors
+    dl $7ED916 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED918 : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0000 ; Events, Items, Doors
+    dl $7ED91C : db $02 : dw $1010 ; Events, Items, Doors
+    dl $7ED91E : db $02 : dw $0000 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_zebes_asleep_climb_down:
+    dw #preset_ssrta_zebes_asleep_parlor ; Zebes Asleep: Parlor
+    dl $7E078D : db $02 : dw $8916 ; DDB
+    dl $7E079B : db $02 : dw $92FD ; MDB
+    dl $7E090F : db $02 : dw $2FFF ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0100 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $6000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $041F ; Screen Y position in pixels
+    dl $7E0AF6 : db $02 : dw $01A8 ; Samus X
+    dl $7E0AFA : db $02 : dw $04BB ; Samus Y
+    dw #$FFFF
+.after
+
+preset_ssrta_zebes_asleep_pit_room:
+    dw #preset_ssrta_zebes_asleep_climb_down ; Zebes Asleep: Climb Down
+    dl $7E078D : db $02 : dw $898E ; DDB
+    dl $7E078F : db $02 : dw $0004 ; DoorOut Index
+    dl $7E079B : db $02 : dw $96BA ; MDB
+    dl $7E07C3 : db $02 : dw $F911 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $15BA ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B0 ; GFX Pointers
+    dl $7E090F : db $02 : dw $4000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $5400 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0800 ; Screen Y position in pixels
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $01DB ; Samus X
+    dl $7E0AFA : db $02 : dw $088B ; Samus Y
+    dw #$FFFF
+.after
+
+preset_ssrta_zebes_asleep_morph:
+    dw #preset_ssrta_zebes_asleep_pit_room ; Zebes Asleep: Pit Room
+    dl $7E078D : db $02 : dw $8B9E ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9E9F ; MDB
+    dl $7E079F : db $02 : dw $0001 ; Region
+    dl $7E07C3 : db $02 : dw $E6B0 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $64BB ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B2 ; GFX Pointers
+    dl $7E07F5 : db $02 : dw $0007 ; Music Track
+    dl $7E090F : db $02 : dw $6000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0500 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0200 ; Screen Y position in pixels
+    dl $7E0A1C : db $02 : dw $0000 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0000 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0580 ; Samus X
+    dl $7E0AFA : db $02 : dw $02A8 ; Samus Y
+    dl $7ED91A : db $02 : dw $0001 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_zebes_asleep_construction_zone:
+    dw #preset_ssrta_zebes_asleep_morph ; Zebes Asleep: Morph
+    dl $7E078F : db $02 : dw $0003 ; DoorOut Index
+    dl $7E090F : db $02 : dw $2000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0700 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $5000 ; Screen subpixel Y position
+    dl $7E09A2 : db $02 : dw $0004 ; Equipped Items
+    dl $7E09A4 : db $02 : dw $0004 ; Collected Items
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $07A2 ; Samus X
+    dl $7E0AFA : db $02 : dw $028B ; Samus Y
+    dl $7ED872 : db $02 : dw $0400 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_zebes_asleep_construction_zone_revisit:
+    dw #preset_ssrta_zebes_asleep_construction_zone ; Zebes Asleep: Construction Zone
+    dl $7E078D : db $02 : dw $8EDA ; DDB
+    dl $7E078F : db $02 : dw $0002 ; DoorOut Index
+    dl $7E079B : db $02 : dw $A107 ; MDB
+    dl $7E090F : db $02 : dw $0000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $9000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0005 ; Missiles
+    dl $7E09C8 : db $02 : dw $0005 ; Max missiles
+    dl $7E0AF6 : db $02 : dw $0055 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED874 : db $02 : dw $0004 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0002 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_zebes_awake_pit_room_revisit:
+    dw #preset_ssrta_zebes_asleep_construction_zone_revisit ; Zebes Asleep: Construction Zone Revisit
+    dl $7E078D : db $02 : dw $8EB6 ; DDB
+    dl $7E079B : db $02 : dw $97B5 ; MDB
+    dl $7E079F : db $02 : dw $0000 ; Region
+    dl $7E07C3 : db $02 : dw $F911 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $43BA ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2AF ; GFX Pointers
+    dl $7E07F5 : db $02 : dw $0003 ; Music Track
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0A1C : db $02 : dw $0000 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0000 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0080 ; Samus X
+    dl $7E0AFA : db $02 : dw $0088 ; Samus Y
+    dl $7ED91A : db $02 : dw $0003 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_zebes_awake_climb_up:
+    dw #preset_ssrta_zebes_awake_pit_room_revisit ; Zebes Awake: Pit Room Revisit
+    dl $7E078D : db $02 : dw $8B92 ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E079B : db $02 : dw $975C ; MDB
+    dl $7E07F3 : db $02 : dw $0009 ; Music Bank
+    dl $7E07F5 : db $02 : dw $0005 ; Music Track
+    dl $7E090F : db $02 : dw $F000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $4400 ; Screen subpixel Y position
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0088 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED820 : db $02 : dw $0001 ; Events, Items, Doors
+    dl $7ED8B2 : db $02 : dw $0400 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0004 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_zebes_awake_parlor_revisit:
+    dw #preset_ssrta_zebes_awake_climb_up ; Zebes Awake: Climb Up
+    dl $7E078D : db $02 : dw $8B7A ; DDB
+    dl $7E079B : db $02 : dw $96BA ; MDB
+    dl $7E090F : db $02 : dw $2000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0100 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $C000 ; Screen subpixel Y position
+    dl $7E0AF6 : db $02 : dw $0196 ; Samus X
+    dl $7E0AFA : db $02 : dw $005B ; Samus Y
+    dw #$FFFF
+.after
+
+preset_ssrta_zebes_awake_bomb_torizo:
+    dw #preset_ssrta_zebes_awake_parlor_revisit ; Zebes Awake: Parlor Revisit
+    dl $7E078D : db $02 : dw $8982 ; DDB
+    dl $7E078F : db $02 : dw $0003 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9879 ; MDB
+    dl $7E090F : db $02 : dw $0000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0200 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $AC00 ; Screen subpixel Y position
+    dl $7E09C6 : db $02 : dw $0000 ; Missiles
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $02C6 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED8B2 : db $02 : dw $2400 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_zebes_awake_alcatraz:
+    dw #preset_ssrta_zebes_awake_bomb_torizo ; Zebes Awake: Bomb Torizo
+    dl $7E078D : db $02 : dw $8BAA ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E090F : db $02 : dw $2001 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $C000 ; Screen subpixel Y position
+    dl $7E09A2 : db $02 : dw $1004 ; Equipped Items
+    dl $7E09A4 : db $02 : dw $1004 ; Collected Items
+    dl $7E09C6 : db $02 : dw $0005 ; Missiles
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0AF6 : db $02 : dw $003E ; Samus X
+    dl $7ED828 : db $02 : dw $0004 ; Events, Items, Doors
+    dl $7ED870 : db $02 : dw $0080 ; Events, Items, Doors
+    dl $7ED8B2 : db $02 : dw $2C00 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0005 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_zebes_awake_terminator:
+    dw #preset_ssrta_zebes_awake_alcatraz ; Zebes Awake: Alcatraz
+    dl $7E078D : db $02 : dw $8BB6 ; DDB
+    dl $7E079B : db $02 : dw $92FD ; MDB
+    dl $7E07C3 : db $02 : dw $C629 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $7CBA ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2AD ; GFX Pointers
+    dl $7E090F : db $02 : dw $6C00 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0100 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $7BFF ; Screen subpixel Y position
+    dl $7E0A1C : db $02 : dw $0041 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0404 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0115 ; Samus X
+    dl $7E0AFA : db $02 : dw $0099 ; Samus Y
+    dw #$FFFF
+.after
+
+preset_ssrta_zebes_awake_green_pirate_shaft:
+    dw #preset_ssrta_zebes_awake_terminator ; Zebes Awake: Terminator
+    dl $7E078D : db $02 : dw $895E ; DDB
+    dl $7E079B : db $02 : dw $990D ; MDB
+    dl $7E07C3 : db $02 : dw $F911 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $43BA ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2AF ; GFX Pointers
+    dl $7E090F : db $02 : dw $7200 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $F800 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $01FC ; Screen Y position in pixels
+    dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0004 ; More position/state
+    dl $7E0AF6 : db $02 : dw $004F ; Samus X
+    dl $7E0AFA : db $02 : dw $0293 ; Samus Y
+    dl $7ED91A : db $02 : dw $0006 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_brinstar_missiles_green_brinstar_elevator:
+    dw #preset_ssrta_zebes_awake_green_pirate_shaft ; Zebes Awake: Green Pirate Shaft
+    dl $7E078D : db $02 : dw $8C22 ; DDB
+    dl $7E078F : db $02 : dw $0002 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9938 ; MDB
+    dl $7E07F5 : db $02 : dw $0003 ; Music Track
+    dl $7E090F : db $02 : dw $B000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $E7FF ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0002 ; Missiles
+    dl $7E0AF6 : db $02 : dw $0082 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED91A : db $02 : dw $0008 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_brinstar_missiles_dachora_room:
+    dw #preset_ssrta_brinstar_missiles_green_brinstar_elevator ; Brinstar Missiles: Green Brinstar Elevator
+    dl $7E078D : db $02 : dw $8C0A ; DDB
+    dl $7E078F : db $02 : dw $0009 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9AD9 ; MDB
+    dl $7E079F : db $02 : dw $0001 ; Region
+    dl $7E07C3 : db $02 : dw $E6B0 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $64BB ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B2 ; GFX Pointers
+    dl $7E07F3 : db $02 : dw $000F ; Music Bank
+    dl $7E07F5 : db $02 : dw $0005 ; Music Track
+    dl $7E090F : db $02 : dw $9000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $2800 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0616 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0000 ; Missiles
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0050 ; Samus X
+    dl $7E0AFA : db $02 : dw $068B ; Samus Y
+    dl $7ED8B4 : db $02 : dw $0004 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0009 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_brinstar_missiles_big_pink:
+    dw #preset_ssrta_brinstar_missiles_dachora_room ; Brinstar Missiles: Dachora Room
+    dl $7E078D : db $02 : dw $8CE2 ; DDB
+    dl $7E078F : db $02 : dw $0005 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9CB3 ; MDB
+    dl $7E090F : db $02 : dw $5000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0600 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $DBFF ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0002 ; Missiles
+    dl $7E0AF6 : db $02 : dw $06A2 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dw #$FFFF
+.after
+
+preset_ssrta_brinstar_missiles_kihunter_guards:
+    dw #preset_ssrta_brinstar_missiles_big_pink ; Brinstar Missiles: Big Pink
+    dl $7E078D : db $02 : dw $8DAE ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9D19 ; MDB
+    dl $7E090F : db $02 : dw $3000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0300 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $001D ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0003 ; Missiles
+    dl $7E0AF6 : db $02 : dw $0362 ; Samus X
+    dl $7ED8B4 : db $02 : dw $0404 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $000C ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_brinstar_missiles_spore_spawn:
+    dw #preset_ssrta_brinstar_missiles_kihunter_guards ; Brinstar Missiles: Kihunter Guards
+    dl $7E078D : db $02 : dw $8DC6 ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9D9C ; MDB
+    dl $7E090F : db $02 : dw $0000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $02E2 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $9800 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0000 ; Missiles
+    dl $7E0AF6 : db $02 : dw $0342 ; Samus X
+    dl $7E0AFA : db $02 : dw $007B ; Samus Y
+    dl $7ED8B4 : db $02 : dw $2404 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_brinstar_missiles_spore_spawn_shaft:
+    dw #preset_ssrta_brinstar_missiles_spore_spawn ; Brinstar Missiles: Spore Spawn
+    dl $7E078D : db $02 : dw $8E3E ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9DC7 ; MDB
+    dl $7E07F3 : db $02 : dw $002A ; Music Bank
+    dl $7E090F : db $02 : dw $EFFF ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $F400 ; Screen subpixel Y position
+    dl $7E09C2 : db $02 : dw $0033 ; Health
+    dl $7E09C6 : db $02 : dw $0002 ; Missiles
+    dl $7E0AF6 : db $02 : dw $0078 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED828 : db $02 : dw $0204 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_brinstar_supers_green_brinstar_elevator:
+    dw #preset_ssrta_zebes_awake_green_pirate_shaft ; Zebes Awake: Green Pirate Shaft
+    dl $7E078D : db $02 : dw $8C22 ; DDB
+    dl $7E078F : db $02 : dw $0002 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9938 ; MDB
+    dl $7E07F5 : db $02 : dw $0003 ; Music Track
+    dl $7E090F : db $02 : dw $B000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $E7FF ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0002 ; Missiles
+    dl $7E0AF6 : db $02 : dw $0082 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED91A : db $02 : dw $0008 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_brinstar_supers_early_supers:
+    dw #preset_ssrta_brinstar_supers_green_brinstar_elevator ; Brinstar Supers: Green Brinstar Elevator
+    dl $7E078D : db $02 : dw $8C0A ; DDB
+    dl $7E078F : db $02 : dw $0009 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9AD9 ; MDB
+    dl $7E079F : db $02 : dw $0001 ; Region
+    dl $7E07C3 : db $02 : dw $E6B0 ; GFX Pointers
+    dl $7E07C5 : db $02 : dw $64BB ; GFX Pointers
+    dl $7E07C7 : db $02 : dw $C2B2 ; GFX Pointers
+    dl $7E07F3 : db $02 : dw $000F ; Music Bank
+    dl $7E07F5 : db $02 : dw $0005 ; Music Track
+    dl $7E090F : db $02 : dw $0000 ; Screen subpixel X position.
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $041C ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0000 ; Missiles
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $00A2 ; Samus X
+    dl $7E0AFA : db $02 : dw $048B ; Samus Y
+    dl $7ED8B4 : db $02 : dw $0002 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $0009 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_brinstar_supers_dachora_room:
+    dw #preset_ssrta_brinstar_supers_early_supers ; Brinstar Supers: Early Supers
+    dl $7E078D : db $02 : dw $8D4E ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9AD9 ; DDB
+    dl $7E090F : db $02 : dw $8000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $061A ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $0059 ; Health
+    dl $7E09C6 : db $02 : dw $0002 ; Missiles
+    dl $7E09CA : db $02 : dw $0004 ; Supers
+    dl $7E09CC : db $02 : dw $0005 ; Max supers
+    dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
+    dl $7E0A1E : db $02 : dw $0008 ; More position/state
+    dl $7E0AF6 : db $02 : dw $0052 ; Samus X
+    dl $7E0AFA : db $02 : dw $068B ; Samus Y
+    dl $7ED872 : db $02 : dw $0401 ; Events, Items, Doors
+    dl $7ED8B4 : db $02 : dw $0006 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $000C ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_brinstar_supers_big_pink:
+    dw #preset_ssrta_brinstar_supers_dachora_room ; Brinstar Supers: Dachora Room
+    dl $7E078D : db $02 : dw $8CE2 ; DDB
+    dl $7E078F : db $02 : dw $0005 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9CB3 ; MDB
+    dl $7E090F : db $02 : dw $6000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0600 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $F000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0004 ; Missiles
+    dl $7E0AF6 : db $02 : dw $06A4 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dw #$FFFF
+.after
+
+preset_ssrta_brinstar_supers_kihunter_guards:
+    dw #preset_ssrta_brinstar_supers_big_pink ; Brinstar Supers: Big Pink
+    dl $7E078D : db $02 : dw $8DAE ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9D19 ; MDB
+    dl $7E090F : db $02 : dw $D000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0300 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $001D ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $005E ; Health
+    dl $7E0AF6 : db $02 : dw $0365 ; Samus X
+    dl $7ED8B4 : db $02 : dw $0406 ; Events, Items, Doors
+    dl $7ED91A : db $02 : dw $000F ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_brinstar_supers_spore_spawn:
+    dw #preset_ssrta_brinstar_supers_kihunter_guards ; Brinstar Supers: Kihunter Guards
+    dl $7E078D : db $02 : dw $8DC6 ; DDB
+    dl $7E078F : db $02 : dw $0000 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9D9C ; MDB
+    dl $7E090F : db $02 : dw $B000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $02E2 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $D400 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
+    dl $7E09C6 : db $02 : dw $0001 ; Missiles
+    dl $7E0AF6 : db $02 : dw $0342 ; Samus X
+    dl $7E0AFA : db $02 : dw $007B ; Samus Y
+    dl $7ED8B4 : db $02 : dw $2406 ; Events, Items, Doors
+    dw #$FFFF
+.after
+
+preset_ssrta_brinstar_supers_spore_spawn_shaft:
+    dw #preset_ssrta_brinstar_supers_spore_spawn ; Brinstar Supers: Spore Spawn
+    dl $7E078D : db $02 : dw $8E3E ; DDB
+    dl $7E078F : db $02 : dw $0001 ; DoorOut Index
+    dl $7E079B : db $02 : dw $9DC7 ; MDB
+    dl $7E07F3 : db $02 : dw $002A ; Music Bank
+    dl $7E090F : db $02 : dw $2000 ; Screen subpixel X position.
+    dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
+    dl $7E0913 : db $02 : dw $EC00 ; Screen subpixel Y position
+    dl $7E0915 : db $02 : dw $000C ; Screen Y position in pixels
+    dl $7E09C2 : db $02 : dw $004E ; Health
+    dl $7E09C6 : db $02 : dw $0003 ; Missiles
+    dl $7E09CA : db $02 : dw $0001 ; Supers
+    dl $7E0AF6 : db $02 : dw $0076 ; Samus X
+    dl $7E0AFA : db $02 : dw $008B ; Samus Y
+    dl $7ED828 : db $02 : dw $0204 ; Events, Items, Doors
+    dw #$FFFF
+.after

--- a/src/presets/ssrta_menu.asm
+++ b/src/presets/ssrta_menu.asm
@@ -1,0 +1,148 @@
+PresetsMenuSsrta:
+    dw #presets_goto_ssrta_zebes_asleep
+    dw #presets_goto_ssrta_zebes_awake
+    dw #presets_goto_ssrta_brinstar_missiles
+    dw #presets_goto_ssrta_brinstar_supers
+    dw #$0000
+    %cm_header("PRESETS FOR SS RTA")
+
+presets_goto_ssrta_zebes_asleep:
+    %cm_submenu("Zebes Asleep", #presets_submenu_ssrta_zebes_asleep)
+
+presets_goto_ssrta_zebes_awake:
+    %cm_submenu("Zebes Awake", #presets_submenu_ssrta_zebes_awake)
+
+presets_goto_ssrta_brinstar_missiles:
+    %cm_submenu("Brinstar Missiles", #presets_submenu_ssrta_brinstar_missiles)
+
+presets_goto_ssrta_brinstar_supers:
+    %cm_submenu("Brinstar Supers", #presets_submenu_ssrta_brinstar_supers)
+
+presets_submenu_ssrta_zebes_asleep:
+    dw #presets_ssrta_zebes_asleep_parlor
+    dw #presets_ssrta_zebes_asleep_climb_down
+    dw #presets_ssrta_zebes_asleep_pit_room
+    dw #presets_ssrta_zebes_asleep_morph
+    dw #presets_ssrta_zebes_asleep_construction_zone
+    dw #presets_ssrta_zebes_asleep_construction_zone_revisit
+    dw #$0000
+    %cm_header("ZEBES ASLEEP")
+
+presets_submenu_ssrta_zebes_awake:
+    dw #presets_ssrta_zebes_awake_pit_room_revisit
+    dw #presets_ssrta_zebes_awake_climb_up
+    dw #presets_ssrta_zebes_awake_parlor_revisit
+    dw #presets_ssrta_zebes_awake_bomb_torizo
+    dw #presets_ssrta_zebes_awake_alcatraz
+    dw #presets_ssrta_zebes_awake_terminator
+    dw #presets_ssrta_zebes_awake_green_pirate_shaft
+    dw #$0000
+    %cm_header("ZEBES AWAKE")
+
+presets_submenu_ssrta_brinstar_missiles:
+    dw #presets_ssrta_brinstar_missiles_green_brinstar_elevator
+    dw #presets_ssrta_brinstar_missiles_dachora_room
+    dw #presets_ssrta_brinstar_missiles_big_pink
+    dw #presets_ssrta_brinstar_missiles_kihunter_guards
+    dw #presets_ssrta_brinstar_missiles_spore_spawn
+    dw #presets_ssrta_brinstar_missiles_spore_spawn_shaft
+    dw #$0000
+    %cm_header("BRINSTAR MISSILES")
+
+presets_submenu_ssrta_brinstar_supers:
+    dw #presets_ssrta_brinstar_supers_green_brinstar_elevator
+    dw #presets_ssrta_brinstar_supers_early_supers
+    dw #presets_ssrta_brinstar_supers_dachora_room
+    dw #presets_ssrta_brinstar_supers_big_pink
+    dw #presets_ssrta_brinstar_supers_kihunter_guards
+    dw #presets_ssrta_brinstar_supers_spore_spawn
+    dw #presets_ssrta_brinstar_supers_spore_spawn_shaft
+    dw #$0000
+    %cm_header("BRINSTAR SUPERS")
+
+; Zebes Asleep
+presets_ssrta_zebes_asleep_parlor:
+    %cm_preset("Parlor", #preset_ssrta_zebes_asleep_parlor)
+
+presets_ssrta_zebes_asleep_climb_down:
+    %cm_preset("Climb Down", #preset_ssrta_zebes_asleep_climb_down)
+
+presets_ssrta_zebes_asleep_pit_room:
+    %cm_preset("Pit Room", #preset_ssrta_zebes_asleep_pit_room)
+
+presets_ssrta_zebes_asleep_morph:
+    %cm_preset("Morph", #preset_ssrta_zebes_asleep_morph)
+
+presets_ssrta_zebes_asleep_construction_zone:
+    %cm_preset("Construction Zone", #preset_ssrta_zebes_asleep_construction_zone)
+
+presets_ssrta_zebes_asleep_construction_zone_revisit:
+    %cm_preset("Construction Zone Revisit", #preset_ssrta_zebes_asleep_construction_zone_revisit)
+
+
+; Zebes Awake
+presets_ssrta_zebes_awake_pit_room_revisit:
+    %cm_preset("Pit Room Revisit", #preset_ssrta_zebes_awake_pit_room_revisit)
+
+presets_ssrta_zebes_awake_climb_up:
+    %cm_preset("Climb Up", #preset_ssrta_zebes_awake_climb_up)
+
+presets_ssrta_zebes_awake_parlor_revisit:
+    %cm_preset("Parlor Revisit", #preset_ssrta_zebes_awake_parlor_revisit)
+
+presets_ssrta_zebes_awake_bomb_torizo:
+    %cm_preset("Bomb Torizo", #preset_ssrta_zebes_awake_bomb_torizo)
+
+presets_ssrta_zebes_awake_alcatraz:
+    %cm_preset("Alcatraz", #preset_ssrta_zebes_awake_alcatraz)
+
+presets_ssrta_zebes_awake_terminator:
+    %cm_preset("Terminator", #preset_ssrta_zebes_awake_terminator)
+
+presets_ssrta_zebes_awake_green_pirate_shaft:
+    %cm_preset("Green Pirate Shaft", #preset_ssrta_zebes_awake_green_pirate_shaft)
+
+
+; Brinstar Missiles
+presets_ssrta_brinstar_missiles_green_brinstar_elevator:
+    %cm_preset("Green Brinstar Elevator", #preset_ssrta_brinstar_missiles_green_brinstar_elevator)
+
+presets_ssrta_brinstar_missiles_dachora_room:
+    %cm_preset("Dachora Room", #preset_ssrta_brinstar_missiles_dachora_room)
+
+presets_ssrta_brinstar_missiles_big_pink:
+    %cm_preset("Big Pink", #preset_ssrta_brinstar_missiles_big_pink)
+
+presets_ssrta_brinstar_missiles_kihunter_guards:
+    %cm_preset("Kihunter Guards", #preset_ssrta_brinstar_missiles_kihunter_guards)
+
+presets_ssrta_brinstar_missiles_spore_spawn:
+    %cm_preset("Spore Spawn", #preset_ssrta_brinstar_missiles_spore_spawn)
+
+presets_ssrta_brinstar_missiles_spore_spawn_shaft:
+    %cm_preset("Spore Spawn Shaft", #preset_ssrta_brinstar_missiles_spore_spawn_shaft)
+
+
+; Brinstar Supers
+presets_ssrta_brinstar_supers_green_brinstar_elevator:
+    %cm_preset("Green Brinstar Elevator", #preset_ssrta_brinstar_supers_green_brinstar_elevator)
+
+presets_ssrta_brinstar_supers_early_supers:
+    %cm_preset("Early Supers", #preset_ssrta_brinstar_supers_early_supers)
+
+presets_ssrta_brinstar_supers_dachora_room:
+    %cm_preset("Dachora Room", #preset_ssrta_brinstar_supers_dachora_room)
+
+presets_ssrta_brinstar_supers_big_pink:
+    %cm_preset("Big Pink", #preset_ssrta_brinstar_supers_big_pink)
+
+presets_ssrta_brinstar_supers_kihunter_guards:
+    %cm_preset("Kihunter Guards", #preset_ssrta_brinstar_supers_kihunter_guards)
+
+presets_ssrta_brinstar_supers_spore_spawn:
+    %cm_preset("Spore Spawn", #preset_ssrta_brinstar_supers_spore_spawn)
+
+presets_ssrta_brinstar_supers_spore_spawn_shaft:
+    %cm_preset("Spore Spawn Shaft", #preset_ssrta_brinstar_supers_spore_spawn_shaft)
+
+

--- a/tools/sm_teledump.lua
+++ b/tools/sm_teledump.lua
@@ -1,4 +1,4 @@
-local CAT = "14ice" -- prkd, hundo, rbo, kpdr25, gtclassic, kpdr21, 14ice
+local CAT = "ssrta" -- prkd, hundo, rbo, kpdr25, gtclassic, kpdr21, 14ice, ssrta, crocrta, gtrta
 
 local last_state = {} -- holds all state that has been changed up untill last save
 
@@ -161,6 +161,22 @@ local SEGMENTS = {
         { ["name"] = "Lower Norfair", ["steps"] = {} },
         { ["name"] = "Maridia", ["steps"] = {} },
         { ["name"] = "Tourian", ["steps"] = {} },
+    },
+    ["ssrta"] = {
+        { ["name"] = "Zebes Asleep", ["steps"] = {} },
+        { ["name"] = "Zebes Awake", ["steps"] = {} },
+        { ["name"] = "Brinstar Missiles", ["steps"] = {} },
+    },
+    ["crocrta"] = {
+        { ["name"] = "Zebes Asleep", ["steps"] = {} },
+        { ["name"] = "Zebes Awake", ["steps"] = {} },
+        { ["name"] = "Brinstar", ["steps"] = {} },
+        { ["name"] = "Norfair", ["steps"] = {} },
+    },
+    ["gtrta"] = {
+        { ["name"] = "Crateria", ["steps"] = {} },
+        { ["name"] = "Brinstar", ["steps"] = {} },
+        { ["name"] = "Bootless Upper Norfair", ["steps"] = {} },
     },
 }
 
@@ -920,6 +936,104 @@ local STEPS = {
         [177624] = { ["segment_no"] = 8, ["name"] = "Zeb Skip" },
         [205325] = { ["segment_no"] = 8, ["name"] = "Escape Room 3" },
         [209282] = { ["segment_no"] = 8, ["name"] = "Escape Parlor" },
+    },
+    ["ssrta"] = {
+		-- Zebes Asleep
+        [1692] = { ["segment_no"] = 1, ["name"] = "Parlor" },
+        [2555] = { ["segment_no"] = 1, ["name"] = "Climb Down" },
+        [3050] = { ["segment_no"] = 1, ["name"] = "Pit Room" },
+        [4411] = { ["segment_no"] = 1, ["name"] = "Morph" },
+        [5358] = { ["segment_no"] = 1, ["name"] = "Construction Zone" },
+        [6451] = { ["segment_no"] = 1, ["name"] = "Construction Zone Revisit" },
+		-- Zebes Awake
+        [7927] = { ["segment_no"] = 2, ["name"] = "Pit Room Revisit" },
+        [8545] = { ["segment_no"] = 2, ["name"] = "Climb Up" },
+        [9755] = { ["segment_no"] = 2, ["name"] = "Parlor Revisit" },
+        [11145] = { ["segment_no"] = 2, ["name"] = "Bomb Torizo" },
+        [13771] = { ["segment_no"] = 2, ["name"] = "Alcatraz" },
+        [14325] = { ["segment_no"] = 2, ["name"] = "Terminator" },
+        [15123] = { ["segment_no"] = 2, ["name"] = "Green Pirate Shaft" },
+		-- Brinstar Missiles
+        [16419] = { ["segment_no"] = 3, ["name"] = "Green Brinstar Elevator" },
+        [17675] = { ["segment_no"] = 3, ["name"] = "Dachora Room" },
+        [18763] = { ["segment_no"] = 3, ["name"] = "Big Pink" },
+        [20580] = { ["segment_no"] = 3, ["name"] = "Kihunter Guards" },
+        [21020] = { ["segment_no"] = 3, ["name"] = "Spore Spawn" },
+        [24683] = { ["segment_no"] = 3, ["name"] = "Spore Spawn Shaft" },
+    },
+    ["crocrta"] = {
+		-- Zebes Asleep
+        [1692] = { ["segment_no"] = 1, ["name"] = "Parlor" },
+        [2555] = { ["segment_no"] = 1, ["name"] = "Climb Down" },
+        [3050] = { ["segment_no"] = 1, ["name"] = "Pit Room" },
+        [4411] = { ["segment_no"] = 1, ["name"] = "Morph" },
+        [5358] = { ["segment_no"] = 1, ["name"] = "Construction Zone" },
+        [6451] = { ["segment_no"] = 1, ["name"] = "Construction Zone Revisit" },
+		-- Zebes Awake
+        [7927] = { ["segment_no"] = 2, ["name"] = "Pit Room Revisit" },
+        [8545] = { ["segment_no"] = 2, ["name"] = "Climb Up" },
+        [9755] = { ["segment_no"] = 2, ["name"] = "Parlor Revisit" },
+        [11145] = { ["segment_no"] = 2, ["name"] = "Bomb Torizo" },
+        [13771] = { ["segment_no"] = 2, ["name"] = "Alcatraz" },
+        [14325] = { ["segment_no"] = 2, ["name"] = "Terminator" },
+        [15459] = { ["segment_no"] = 2, ["name"] = "Green Pirate Shaft" },
+		-- Brinstar
+        [16712] = { ["segment_no"] = 3, ["name"] = "Green Brinstar Elevator" },
+        [17820] = { ["segment_no"] = 3, ["name"] = "Early Supers" },
+        [19345] = { ["segment_no"] = 3, ["name"] = "Dachora Room" },
+        [20446] = { ["segment_no"] = 3, ["name"] = "Big Pink" },
+        [22914] = { ["segment_no"] = 3, ["name"] = "Green Hill Zone" },
+        [24385] = { ["segment_no"] = 3, ["name"] = "Red Tower" },
+        [25035] = { ["segment_no"] = 3, ["name"] = "Skree Boost" },
+		-- Norfair
+        [27345] = { ["segment_no"] = 4, ["name"] = "Business Center" },
+        [27630] = { ["segment_no"] = 4, ["name"] = "Hi Jump E-tank" },
+        [28520] = { ["segment_no"] = 4, ["name"] = "Business Center Revisit" },
+        [29200] = { ["segment_no"] = 4, ["name"] = "Hell Run" },
+        [31068] = { ["segment_no"] = 4, ["name"] = "Bubble Mountain" },
+        [32075] = { ["segment_no"] = 4, ["name"] = "Farm Room" },
+        [34369] = { ["segment_no"] = 4, ["name"] = "Acid Snakes Room" },
+        [35100] = { ["segment_no"] = 4, ["name"] = "Crocomire" },
+    },
+    ["gtrta"] = {
+		-- Crateria
+        [1692] = { ["segment_no"] = 1, ["name"] = "Parlor" },
+        [2555] = { ["segment_no"] = 1, ["name"] = "Climb Down" },
+        [3050] = { ["segment_no"] = 1, ["name"] = "Pit Room" },
+        [4411] = { ["segment_no"] = 1, ["name"] = "Morph" },
+        [5358] = { ["segment_no"] = 1, ["name"] = "Construction Zone" },
+        [6451] = { ["segment_no"] = 1, ["name"] = "Construction Zone Revisit" },
+        [7927] = { ["segment_no"] = 1, ["name"] = "Pit Room Revisit" },
+        [8545] = { ["segment_no"] = 1, ["name"] = "Climb Up" },
+        [9755] = { ["segment_no"] = 1, ["name"] = "Parlor Revisit" },
+        [11145] = { ["segment_no"] = 1, ["name"] = "Bomb Torizo" },
+        [13771] = { ["segment_no"] = 1, ["name"] = "Alcatraz" },
+        [14325] = { ["segment_no"] = 1, ["name"] = "Terminator" },
+        [15459] = { ["segment_no"] = 1, ["name"] = "Green Pirate Shaft" },
+		-- Brinstar
+        [16712] = { ["segment_no"] = 2, ["name"] = "Green Brinstar Elevator" },
+        [17820] = { ["segment_no"] = 2, ["name"] = "Early Supers" },
+        [19345] = { ["segment_no"] = 2, ["name"] = "Dachora Room" },
+        [20446] = { ["segment_no"] = 2, ["name"] = "Big Pink" },
+        [22081] = { ["segment_no"] = 2, ["name"] = "Green Hill Zone" },
+        [23008] = { ["segment_no"] = 2, ["name"] = "Red Tower" },
+        [23775] = { ["segment_no"] = 2, ["name"] = "Hellway" },
+        [25443] = { ["segment_no"] = 2, ["name"] = "Leaving Power Bombs" },
+        [27212] = { ["segment_no"] = 2, ["name"] = "Skree Boost" },
+        [28574] = { ["segment_no"] = 2, ["name"] = "Entering Kraids Lair" },
+        [29975] = { ["segment_no"] = 2, ["name"] = "Baby Kraid (Entering)" },
+        [31005] = { ["segment_no"] = 2, ["name"] = "Kraid" },
+        [34021] = { ["segment_no"] = 2, ["name"] = "Baby Kraid (Exiting)" },
+        [35390] = { ["segment_no"] = 2, ["name"] = "Kraid E-tank" },
+		-- Bootless Norfair
+        [37680] = { ["segment_no"] = 3, ["name"] = "Business Center" },
+        [38887] = { ["segment_no"] = 3, ["name"] = "Cathedral" },
+        [40264] = { ["segment_no"] = 3, ["name"] = "Bubble Mountain" },
+        [41125] = { ["segment_no"] = 3, ["name"] = "Magdollite Tunnel" },
+        [42235] = { ["segment_no"] = 3, ["name"] = "Lava Dive" },
+        [44260] = { ["segment_no"] = 3, ["name"] = "LN Main Hall" },
+        [45093] = { ["segment_no"] = 3, ["name"] = "Green Gate Glitch" },
+        [46460] = { ["segment_no"] = 3, ["name"] = "Golden Torizo" },
     },
 }
 

--- a/website/ClientApp/src/components/Changelog.js
+++ b/website/ClientApp/src/components/Changelog.js
@@ -32,6 +32,7 @@ export class Changelog extends Component {
                                                 <li>Move KPDR 21% presets to the combined ROM. (2.0.10)</li>
                                                 <li>Add cooldown timer to the Infohud Mode options. (2.0.11)</li>
                                                 <li>Add support for 14% Ice presets. (2.0.12)</li>
+                                                <li>Add support for individual Miniboss RTA presets (Spore Spawn, Crocomire, and Golden Torizo) (2.0.13)</li>
                                             </ul>
                                         </CardBody>
                                     </Card>

--- a/website/ClientApp/src/components/Home.js
+++ b/website/ClientApp/src/components/Home.js
@@ -10,7 +10,7 @@ export class Home extends Component {
       <Row className="justify-content-center">
         <Col md="8">
           <div>
-              <Patcher version="2.0.12"/>
+              <Patcher version="2.0.13"/>
           </div>
         </Col>
       </Row>

--- a/website/ClientApp/src/components/Patcher.js
+++ b/website/ClientApp/src/components/Patcher.js
@@ -14,6 +14,8 @@ import saveStatePatchGtclassic from '../files/saveStatePatchGtclassic.ips';
 import noSaveStatePatchGtclassic from '../files/noSaveStatePatchGtclassic.ips';
 import saveStatePatch14ice from '../files/saveStatePatch14ice.ips';
 import noSaveStatePatch14ice from '../files/noSaveStatePatch14ice.ips';
+import saveStatePatchMiniboss from '../files/saveStatePatchMiniboss.ips';
+import noSaveStatePatchMiniboss from '../files/noSaveStatePatchMiniboss.ips';
 
 export class Patcher extends Component {
     static displayName = Patcher.name;
@@ -108,6 +110,8 @@ export class Patcher extends Component {
                 return new Uint8Array(await (await fetch(saveStatePatchGtclassic, {cache: "no-store"})).arrayBuffer());
             else if(this.state.category === "14ice")
                 return new Uint8Array(await (await fetch(saveStatePatch14ice, {cache: "no-store"})).arrayBuffer());
+            else if(this.state.category === "miniboss")
+                return new Uint8Array(await (await fetch(saveStatePatchMiniboss, {cache: "no-store"})).arrayBuffer());
             else
                 return null;
         else if(this.state.romType === "nosavestates")
@@ -121,6 +125,8 @@ export class Patcher extends Component {
                 return new Uint8Array(await (await fetch(noSaveStatePatchGtclassic, {cache: "no-store"})).arrayBuffer());
             else if(this.state.category === "14ice")
                 return new Uint8Array(await (await fetch(noSaveStatePatch14ice, {cache: "no-store"})).arrayBuffer());
+            else if(this.state.category === "miniboss")
+                return new Uint8Array(await (await fetch(noSaveStatePatchMiniboss, {cache: "no-store"})).arrayBuffer());
             else
                 return null;
         else
@@ -138,6 +144,8 @@ export class Patcher extends Component {
                 return "SM Practice Hack " + this.props.version + " (Savestates) GT Classic.sfc";
             else if(this.state.category === "14ice")
                 return "SM Practice Hack " + this.props.version + " (Savestates) 14% Ice.sfc";
+            else if(this.state.category === "miniboss")
+                return "SM Practice Hack " + this.props.version + " (Savestates) Miniboss RTAs.sfc";
             else
                 // Return this for unknown category, as well as combined
                 return "SM Practice Hack " + this.props.version + " (Savestates).sfc";
@@ -150,6 +158,8 @@ export class Patcher extends Component {
                 return "SM Practice Hack " + this.props.version + " (No savestates) GT Classic.sfc";
             else if(this.state.category === "14ice")
                 return "SM Practice Hack " + this.props.version + " (No savestates) 14% Ice.sfc";
+            else if(this.state.category === "miniboss")
+                return "SM Practice Hack " + this.props.version + " (No savestates) Miniboss RTAs.sfc";
             else
                 // Return this for unknown category, as well as combined
                 return "SM Practice Hack " + this.props.version + " (No savestates).sfc";
@@ -210,6 +220,7 @@ export class Patcher extends Component {
                                             <option value="kpdr25">KPDR 25% (Early Ice, Spazer, 5 tank, 25/10/5)</option>
                                             <option value="gtclassic">GT Classic</option>
                                             <option value="14ice">14% Ice</option>
+                                            <option value="miniboss">Miniboss RTAs</option>
                                         </Input>
                                     </InputGroup>
                                 </Col>


### PR DESCRIPTION
Spore Spawn, Crocomire, and Golden Torizo RTAs are included. SS RTA includes missile-only and super missile routes. GT RTA includes bootless and hi jump routes.

Botwoon and All Miniboss RTA routes will be on a separate pull request.