### PR TITLE
Prevent Murder Beam - Issue #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,3 @@ The build script will create two IPS patch files for the practice hack. The patc
 
 * PAL region roms are no longer supported in the main branch. See https://github.com/InsaneFirebat/sm_practice_hack/tree/PAL-v1.43 for the latest working PAL revision.
 * A crash will occur upon completing the game and leaving Zebes.
-* Equipment options that contain both Spazer and Plasma may equip them at the same time, which can lead to "Murder Beam" related crashes.

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -135,7 +135,7 @@ MainMenu:
     dw #mm_goto_rngmenu
     dw #mm_goto_ctrlsmenu
     dw #$0000
-    %cm_header("SM PRACTICE HACK 2.0.15")
+    %cm_header("SM PRACTICE HACK 2.1")
 
 mm_goto_equipment:
     %cm_submenu("Equipment", #EquipmentMenu)
@@ -337,7 +337,7 @@ action_category:
     LDA.l .table, X : STA $7E09A4 : STA $7E09A2 : INX #2
 
     ; Beams
-    LDA.l .table, X : STA $7E09A8 : STA $7E09A6 : INX #2
+    LDA.l .table, X : STA $7E09A8 : AND #$FFFB : STA $7E09A6 : INX #2
 
     ; Health
     LDA.l .table, X : STA $7E09C2 : STA $7E09C4 : INX #2

--- a/website/ClientApp/src/components/Changelog.js
+++ b/website/ClientApp/src/components/Changelog.js
@@ -16,6 +16,21 @@ export class Changelog extends Component {
                                 <Col>
                                     <Card>
                                         <CardBody>
+                                            <h2>Version 2.1</h2>
+                                            <p>Changes since 2.0.15:</p>
+                                            <h5>Changes:</h5>
+                                            <ul>
+                                                <li>Prevent accidental Murder Beam after setting Equipment from menu. (2.1)</li>
+                                            </ul>
+                                        </CardBody>
+                                    </Card>
+                                </Col>
+                            </Row>
+                            <br />
+                            <Row>
+                                <Col>
+                                    <Card>
+                                        <CardBody>
                                             <h2>Version 2.0.x</h2>
                                             <p>Changes since 2.0:</p>
                                             <h5>Changes:</h5>
@@ -32,7 +47,7 @@ export class Changelog extends Component {
                                                 <li>Move KPDR 21% presets to the combined ROM. (2.0.10)</li>
                                                 <li>Add cooldown timer to the Infohud Mode options. (2.0.11)</li>
                                                 <li>Add support for 14% Ice presets. (2.0.12)</li>
-                                                <li>Included all preset categories in the sam ROM (2.0.13)</li>
+                                                <li>Included all preset categories in the same ROM (2.0.13)</li>
                                                 <li>Add support for 14% Speed and Any% All Bosses (multiple routes). (2.0.14)</li>
                                                 <li>Add support for 100% Early Croc route. Changed default shortcut for Load Preset. (2.0.15)</li>
                                             </ul>

--- a/website/ClientApp/src/components/Help.js
+++ b/website/ClientApp/src/components/Help.js
@@ -53,7 +53,7 @@ export class Help extends Component {
                                 <Col>Closes the in-game menu</Col>
                             </Row>
                             <Row>
-                                <Col md="2" style={{fontWeight: 'bold'}}>Select+B+L</Col>
+                                <Col md="2" style={{fontWeight: 'bold'}}>Start+Y+L</Col>
                                 <Col>Reloads the last used preset (configurable in shortcuts menu)</Col>
                             </Row>
                             <br />

--- a/website/ClientApp/src/components/Home.js
+++ b/website/ClientApp/src/components/Home.js
@@ -10,7 +10,7 @@ export class Home extends Component {
       <Row className="justify-content-center">
         <Col md="8">
           <div>
-              <Patcher version="2.0.15"/>
+              <Patcher version="2.1"/>
           </div>
         </Col>
       </Row>

--- a/website/ClientApp/src/components/Patcher.js
+++ b/website/ClientApp/src/components/Patcher.js
@@ -137,7 +137,7 @@ export class Patcher extends Component {
                                             <InputGroupText>Type</InputGroupText>                                            
                                         </InputGroupAddon>
                                         <Input type="select" id="type" defaultValue={this.state.romType} onChange={(e) => this.updateType(e)}>
-                                            <option value="savestates">With Save States (SD2SNES only)</option>
+                                            <option value="savestates">With Save States (SD2SNES/FXPAK only)</option>
                                             <option value="nosavestates">Without Save States (Emu/VC/Classic etc)</option>
                                         </Input>
                                     </InputGroup>


### PR DESCRIPTION
This pull fixes #18 by disabling Spazer when setting beams from the Equipment menu.

The version number has been bumped up from 2.0.15 to 2.1
FXPAK has been added to the label for the savestate version on the website. SD2SNES has been rebranded to FXPAK to avoid legal issues with the name.