### PR TITLE
Added Shine Tune and Shot Timer to the Infohud Mode options

### DIFF
--- a/src/defines.asm
+++ b/src/defines.asm
@@ -6,12 +6,15 @@
 !ram_transition_counter = $7FFB0E
 !ram_last_door_lag_frames = $7FFB10
 
+!ram_armed_shine_duration = $7FFB14
 !ram_etanks = $7FFB12 ; ??
 !ram_max_etanks = $7FFB24 ; ??
 !ram_last_hp = $7FFB9A
 
 !ram_slowdown_mode = $7EFFFC
 !ram_slowdown_frames = $7FFB52
+!ram_shine_dash_held_late = $7FFB1A
+!ram_shine_counter = $7FFB30
 !ram_cooldown_counter = $7FFB32
 !ram_xpos = $7FFB34
 !ram_ypos = $7FFB36
@@ -20,9 +23,6 @@
 !ram_vertical_speed = $7FFB3C
 !ram_mb_hp = $7FFB3E
 !ram_enemy_hp = $7FFB40
-!ram_shine_counter_1 = $7FFB30 ; goes 1-A
-!ram_shine_counter_2 = $7FFB14 ; armed shine duration
-!ram_shine_counter_3 = $7FFB1A ; armed shine duration 2
 !ram_magic_pants_1 = $7FFB64
 !ram_magic_pants_2 = $7FFB66
 !ram_magic_pants_3 = $7FFB70
@@ -32,6 +32,7 @@
 !ram_xfac_counter = $7FFB1E
 !ram_lag_counter = $7FFB96
 !ram_last_lag_counter = $7FFB98
+!ram_shot_timer = $7FFB9E
 
 !ram_phantoon_rng_1 = $7FFB82
 !ram_phantoon_rng_2 = $7FFB84
@@ -62,6 +63,15 @@
 !ram_cm_ctrl_mode = $7FFBC0
 !ram_cm_ctrl_timer = $7FFBC2
 !ram_cm_ctrl_last_input = $7FFBC4
+
+!ram_shinefinetune_early_1 = $7FFBD0
+!ram_shinefinetune_late_1 = $7FFBD2
+!ram_shinefinetune_early_2 = $7FFBD4
+!ram_shinefinetune_late_2 = $7FFBD6
+!ram_shinefinetune_early_3 = $7FFBD8
+!ram_shinefinetune_late_3 = $7FFBDA
+!ram_shinefinetune_early_4 = $7FFBDC
+!ram_shinefinetune_late_4 = $7FFBDE
 
 ; -----
 ; SRAM
@@ -135,6 +145,18 @@
 !IH_RESET = #$0200 ; left
 !IH_STATUS_R = #$0010 ; r
 !IH_STATUS_L = #$0020 ; l
+
+!IH_INPUT_UP = $7E09AA
+!IH_INPUT_DOWN = $7E09AC
+!IH_INPUT_LEFT = $7E09AE
+!IH_INPUT_RIGHT = $7E09B0
+!IH_INPUT_SHOOT = $7E09B2
+!IH_INPUT_JUMP = $7E09B4
+!IH_INPUT_RUN = $7E09B6
+!IH_INPUT_ITEM_CANCEL = $7E09B8
+!IH_INPUT_ITEM_SELECT = $7E09BA
+!IH_INPUT_ANGLE_UP = $7E09BC
+!IH_INPUT_ANGLE_DOWN = $7E09BE
 
 ; ------------
 ; Presets

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -135,7 +135,7 @@ MainMenu:
     dw #mm_goto_rngmenu
     dw #mm_goto_ctrlsmenu
     dw #$0000
-    %cm_header("SM PRACTICE HACK 2.1")
+    %cm_header("SM PRACTICE HACK 2.1.1")
 
 mm_goto_equipment:
     %cm_submenu("Equipment", #EquipmentMenu)
@@ -818,6 +818,8 @@ ih_display_mode:
     db #$28, " X POSITION", #$FF
     db #$28, " Y POSITION", #$FF
     db #$28, "   COOLDOWN", #$FF
+    db #$28, " SHINE TUNE", #$FF
+    db #$28, " SHOT TIMER", #$FF
     db #$FF
 
 ih_room_counter:

--- a/website/ClientApp/src/components/Changelog.js
+++ b/website/ClientApp/src/components/Changelog.js
@@ -16,11 +16,12 @@ export class Changelog extends Component {
                                 <Col>
                                     <Card>
                                         <CardBody>
-                                            <h2>Version 2.1</h2>
+                                            <h2>Version 2.1.x</h2>
                                             <p>Changes since 2.0.15:</p>
                                             <h5>Changes:</h5>
                                             <ul>
                                                 <li>Prevent accidental Murder Beam after setting Equipment from menu. (2.1)</li>
+                                                <li>Added Shine Tune and Shot Timer to the Infohud Mode options. (2.1.1)</li>
                                             </ul>
                                         </CardBody>
                                     </Card>

--- a/website/ClientApp/src/components/Home.js
+++ b/website/ClientApp/src/components/Home.js
@@ -10,7 +10,7 @@ export class Home extends Component {
       <Row className="justify-content-center">
         <Col md="8">
           <div>
-              <Patcher version="2.1"/>
+              <Patcher version="2.1.1"/>
           </div>
         </Col>
       </Row>


### PR DESCRIPTION
Hi!
Please review before merging.  While I have plenty of C/C++ experience, this is more work in assembly than I have ever done.  Fortunately your source code was easy enough to follow, and the SM RAM maps available out there helped fill in the gaps.  The changes looked good in testing.

The shot timer is easy enough to understand (time between initially pressing the shoot button, hopefully useful for learning doppler).  For the "shine tune" feature, I made a video.  I plan to redo the video because of the bad audio/video sync (sorry!) and also I made an incorrect statement in there and I forgot to talk about stuttering.  Despite all that, it's good enough that you can see what the shine tune does.  I start demoing shine tune halfway through the video:
https://www.twitch.tv/videos/684151396

Edit: also forgot to mention you mention cases where shine tune numbers will be overwritten, for example when transitioning to another room.  Also I'll drop the complaint about the input viewer; is that just me?  I find it's very sluggish when using the original practice hack version 2.0.15 or my 2.1.1 version, but it works fine with the vanilla rom.  Then today I see Zeni using the practice hack with input viewer and his is working fine.

Edit: Made a better video, included stuttering this time
https://www.twitch.tv/videos/684595233