### PR TITLE
Update create_ips.py

### DIFF
--- a/resources/create_ips.py
+++ b/resources/create_ips.py
@@ -44,7 +44,7 @@ for k in patches:
 
 
 d_patch = [0x50, 0x41, 0x54, 0x43, 0x48] + d_patch + [0x45, 0x4f, 0x46]
-fo.write(bytes(d_patch))
+fo.write(bytearray(d_patch))
 fo.close()
 f_ff.close()
 f_zero.close()


### PR DESCRIPTION
per the previous fix submitted and found by chabo in "create_dummies.py": 

fo.write(bytes) needs to be fo.write(bytearray), otherwise strings are written to the file, not the binary data

![image](https://user-images.githubusercontent.com/20601663/94614668-6386f300-025b-11eb-8c58-991dd8cfbfed.png)
