### PR TITLE
Added Spikesuit to Infohud menu and Shine to PB to Room Start menu

### DIFF
--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -135,7 +135,7 @@ MainMenu:
     dw #mm_goto_rngmenu
     dw #mm_goto_ctrlsmenu
     dw #$0000
-    %cm_header("SM PRACTICE HACK 2.1.2")
+    %cm_header("SM PRACTICE HACK 2.1.3")
 
 mm_goto_equipment:
     %cm_submenu("Equipment", #EquipmentMenu)
@@ -816,6 +816,7 @@ ih_display_mode:
     db #$28, "       DASH", #$FF
     db #$28, " SHINE TUNE", #$FF
     db #$28, "    IFRAMES", #$FF
+    db #$28, "  SPIKESUIT", #$FF
     db #$28, "LAG COUNTER", #$FF
     db #$28, " X POSITION", #$FF
     db #$28, " Y POSITION", #$FF
@@ -832,6 +833,7 @@ ih_room_strat:
     db #$28, "Room Strat", #$FF
     db #$28, "      MB HP", #$FF
     db #$28, "   MOAT CWJ", #$FF
+    db #$28, "SHINE TO PB", #$FF
     db #$FF
 
 ih_room_counter:

--- a/website/ClientApp/src/components/Changelog.js
+++ b/website/ClientApp/src/components/Changelog.js
@@ -25,6 +25,7 @@ export class Changelog extends Component {
                                                 <li>Reordered Infohud Mode options and added Room Strat menu with Moat CWJ. (2.1.2)</li>
                                                 <li>Added Horiz Speed (speed + momentum) and Jump Press to Infohud Mode options. (2.1.2)</li>
                                                 <li>Added subpixels to position and speed options and improved Shine Tune feedback. (2.1.2)</li>
+                                                <li>Added Spikesuit to Infohud Mode options and Shine to PB to Room Strat options. (2.1.3)</li>
                                             </ul>
                                         </CardBody>
                                     </Card>

--- a/website/ClientApp/src/components/Home.js
+++ b/website/ClientApp/src/components/Home.js
@@ -10,7 +10,7 @@ export class Home extends Component {
       <Row className="justify-content-center">
         <Col md="8">
           <div>
-              <Patcher version="2.1.2"/>
+              <Patcher version="2.1.3"/>
           </div>
         </Col>
       </Row>


### PR DESCRIPTION
I got some feedback on the spikesuit feature, made a couple adjustments, I think it is ready.  More on that can be found in zeni's discord:
https://discord.com/channels/415530255311175681/451079239773585428/769711125247295528

Shine to PB is the same as the shinespark counter which counts down the 3 seconds of having charged shinespark.  The only difference is it also prints the time when you lay a power bomb, which I think could be useful for back gauntlet spark.  If you don't lay the power bomb quickly then you won't have enough time to activate the spark.