### PR TITLE
Spore Spawn Crash

### DIFF
--- a/src/rng.asm
+++ b/src/rng.asm
@@ -199,7 +199,7 @@ hook_botwoon_rng:
     RTL
 
 
-org $A5EE50
+org $A5F960
 hook_draygon_rng_left:
 {
     LDA !ram_draygon_rng_left : BEQ .no_manip


### PR DESCRIPTION
This fixes a crash I caused by dropping my Draygon RNG code in the middle of Spore Spawn's data. That last entry in the disassembly wasn't the freespace pointer like usual. http://patrickjohnston.org/bank/A5