### PR TITLE
Update 2.2.3

### DIFF
--- a/src/defines.asm
+++ b/src/defines.asm
@@ -86,6 +86,23 @@
 
 !ram_sprite_prio_flag = $7FFBE0
 
+!ram_watch_left = $7FFC30
+!ram_watch_left_hud = $7FFC32
+!ram_watch_left_hi = $7FFC34
+!ram_watch_left_lo = $7FFC36
+!ram_watch_right = $7FFC38
+!ram_watch_right_hud = $7FFC3A
+!ram_watch_right_hi = $7FFC3C
+!ram_watch_right_lo = $7FFC3E
+!ram_watch_edit_left = $7FFC40
+!ram_watch_edit_left_hi = $7FFC42
+!ram_watch_edit_left_lo = $7FFC44
+!ram_watch_edit_right = $7FFC46
+!ram_watch_edit_right_hi = $7FFC48
+!ram_watch_edit_right_lo = $7FFC4A
+!ram_watch_edit_lock_left = $7FFC4C
+!ram_watch_edit_lock_right = $7FFC4E
+
 ; -----
 ; SRAM
 ; -----
@@ -139,6 +156,7 @@
 !ACTION_NUMFIELD        = #$0006
 !ACTION_CHOICE          = #$0008
 !ACTION_CTRL_SHORTCUT   = #$000A
+!ACTION_NUMFIELD_HEX    = #$000C
 
 !SOUND_MENU_MOVE = $0039
 !SOUND_MENU_JSR = $0039

--- a/src/defines.asm
+++ b/src/defines.asm
@@ -84,8 +84,6 @@
 !ram_shinetune_early_4 = $7FFBDC
 !ram_shinetune_late_4 = $7FFBDE
 
-!ram_sprite_prio_flag = $7FFBE0
-
 !ram_watch_left = $7FFC30
 !ram_watch_left_hud = $7FFC32
 !ram_watch_left_hi = $7FFC34
@@ -116,6 +114,7 @@
 !sram_ctrl_load_state = $70200A
 !sram_ctrl_save_state = $70200C
 !sram_ctrl_load_last_preset = $70200E
+!sram_ctrl_random_preset = $702024
 
 !sram_artificial_lag = $702010
 !sram_rerandomize = $702012
@@ -127,8 +126,8 @@
 !sram_save_has_set_rng = $70201E
 !sram_preset_category = $702020
 !sram_room_strat = $702022
+!sram_sprite_prio_flag = $702026
 
-!sram_ctrl_random_preset = $702024
 
 ; -------------
 ; Menu

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -30,9 +30,13 @@ org $90A91B      ;minimap drawing routine
 org $90A8EF      ;minimap update during HUD loading
     ; Make sure it only runs when you start a new game
     LDA $0998 : AND #$00FF : CMP #$0006 : BNE +
-    JSL reset_all_counters
+    ; It actually runs when you finish the cutscenes after Ceres
+    JSL post_ceres_timers
     +
     RTL
+
+org $82EE92      ;runs on START GAME
+    JSL startgame_seg_timer
 
 org $90E6AA      ;hijack, runs on gamestate = 08 (main gameplay), handles most updating HUD information
     JSL ih_gamemode_frame : NOP : NOP

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -72,14 +72,41 @@ org $84889F      ;hijack, runs every time an item is picked up
 org $91DAD8      ;hijack, runs after a shinespark has been charged
     JSL ih_shinespark_code
 
-org $8095fc         ;hijack, end of NMI routine to update realtime frames
+org $8095fc      ;hijack, end of NMI routine to update realtime frames
     JML ih_nmi_end
 
-org $A98874         ; update seg timer after MB1 fight
+org $A98874      ; update timers after MB1 fight
     JSL ih_mb1_segment
 
-org $A9BE23         ; update seg timer when baby spawns (off-screen) in MB2 fight
+org $A9BE23      ; update timers when baby spawns (off-screen) in MB2 fight
     JSL ih_mb2_segment
+
+org $A0B9AE      ; update timers when Ridley drops spawn
+    JSL ih_drops_segment
+
+org $A0B9E1      ; update timers when Crocomire drops spawn
+    JSL ih_drops_segment
+
+org $A0BA14      ; update timers when Phantoon drops spawn
+    JSL ih_drops_segment
+
+org $A0BA47      ; update timers when Botwoon drops spawn
+    JSL ih_drops_segment
+
+org $A0BA7A      ; update timers when Kraid drops spawn
+    JSL ih_drops_segment
+
+org $A0BAAD      ; update timers when Bomb Torizo drops spawn
+    JSL ih_drops_segment
+
+org $A0BAE0      ; update timers when Golden Torizo drops spawn
+    JSL ih_drops_segment
+
+org $A0BB13      ; update timers when Spore Spawn drops spawn
+    JSL ih_drops_segment
+
+org $A0BB46      ; update timers when Draygon drops spawn
+    JSL ih_drops_segment
 
 org $9AB200         ; graphics for HUD
 incbin ../resources/hudgfx.bin
@@ -295,6 +322,14 @@ ih_mb2_segment:
     STA $7E7854    ; we overwrote this instruction to get here
 
     JSL ih_update_hud_early
+    RTL
+}
+
+ih_drops_segment:
+{
+    ; runs when boss drops spawn
+    JSL ih_update_hud_early
+    JSL $808111 ; overwritten code
     RTL
 }
 

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -405,6 +405,7 @@ ih_update_hud_code:
     ; Draw Item percent
     .pct
     {
+        LDA !sram_display_mode : CMP #$000E : BEQ .skipToEtanks
         LDA #$0000 : STA !ram_pct_1
 
         ; Max HP (E tanks)
@@ -428,7 +429,7 @@ ih_update_hud_code:
         ; Percent symbol on HUD
         LDA !IH_PERCENT : STA $7EC618
     }
-
+  .skipToEtanks
     ; E-tanks
     LDA !ram_etanks : LDX #$0054 : JSR Draw3
 
@@ -888,7 +889,7 @@ ih_game_loop_code:
   .inc_statusdisplay
     LDA !sram_display_mode
     INC A
-    CMP #$0012
+    CMP #$0013
     BNE +
     LDA #$0000
 +   STA !sram_display_mode
@@ -899,7 +900,7 @@ ih_game_loop_code:
     DEC A
     CMP #$FFFF
     BNE +
-    LDA #$0011
+    LDA #$0012
 +   STA !sram_display_mode
     JMP .update_status
 

--- a/src/infohudmodes.asm
+++ b/src/infohudmodes.asm
@@ -736,8 +736,16 @@ status_vspeed:
   .newjump
     LDA #$0001 : STA !ram_roomstrat_counter : STA !ram_walljump_counter
 
+    ; Print initial jump speed over item%
+    LDA $0B38 : BNE +
+    LDA $7EC612 : STA $14
+    LDA $0B2D : AND #$0FFF
+    LDX #$0012 : JSR Draw4Hex
+    INC $0B38
+    LDA $14 : STA $7EC612
+
     ; If we started falling and space jump might be allowed, time to compare
-    LDA !ram_roomstrat_state : BEQ .done
++   LDA !ram_roomstrat_state : BEQ .done
     BRL .preparecompare
 
   .resetjumpcounter

--- a/src/infohudmodes.asm
+++ b/src/infohudmodes.asm
@@ -737,12 +737,12 @@ status_vspeed:
     LDA #$0001 : STA !ram_roomstrat_counter : STA !ram_walljump_counter
 
     ; Print initial jump speed over item%
-    LDA $0B38 : BNE +
-    LDA $7EC612 : STA $14
+    LDA $0B1A : BNE +
+    LDA $7EC612 : TAY
     LDA $0B2D : AND #$0FFF
     LDX #$0012 : JSR Draw4Hex
-    INC $0B38
-    LDA $14 : STA $7EC612
+    INC $0B1A
+    TYA : STA $7EC612
 
     ; If we started falling and space jump might be allowed, time to compare
 +   LDA !ram_roomstrat_state : BEQ .done

--- a/src/infohudmodes.asm
+++ b/src/infohudmodes.asm
@@ -23,6 +23,7 @@
     dw status_quickdrop
     dw status_walljump
     dw status_shottimer
+    dw status_ramwatch
 
 status_enemyhp:
 {
@@ -929,6 +930,38 @@ status_shottimer:
 
   .inc
     LDA !ram_shot_timer : INC : STA !ram_shot_timer
+    RTS
+}
+
+status_ramwatch:
+{
+    LDA $09C2 : STA !ram_last_hp
+    LDA !ram_watch_left : CMP !ram_watch_left_hud : BNE .refreshLeft
+-   LDA !ram_watch_right : CMP !ram_watch_right_hud : BNE .refreshRight : BRA .write
+
+  .refreshLeft
+    LDA !ram_watch_left : TAX : LDA $7E0000,X : STA !ram_watch_left_hud
+    LDX #$0088 : JSR Draw4Hex : BRA -
+
+  .refreshRight
+    LDA !ram_watch_right : TAX : LDA $7E0000,X : STA !ram_watch_right_hud
+    LDX #$0092 : JSR Draw4Hex
+
+  .write
+    LDA !ram_watch_edit_lock_left : BNE .lock_left
+-   LDA !ram_watch_edit_lock_right : BNE .lock_right
+    BRA .done
+
+  .lock_left
+    LDA !ram_watch_left : TAX
+    LDA !ram_watch_edit_left : STA $7E0000,X
+    BRA -
+
+  .lock_right
+    LDA !ram_watch_right : TAX
+    LDA !ram_watch_edit_right : STA $7E0000,X
+
+  .done
     RTS
 }
 

--- a/src/infohudmodes.asm
+++ b/src/infohudmodes.asm
@@ -738,11 +738,11 @@ status_vspeed:
 
     ; Print initial jump speed over item%
     LDA $0B1A : BNE +
-    LDA $7EC612 : TAY
+    LDA $7EC612 : STA $14
     LDA $0B2D : AND #$0FFF
     LDX #$0012 : JSR Draw4Hex
     INC $0B1A
-    TYA : STA $7EC612
+    LDA $14 : STA $7EC612
 
     ; If we started falling and space jump might be allowed, time to compare
 +   LDA !ram_roomstrat_state : BEQ .done

--- a/src/init.asm
+++ b/src/init.asm
@@ -77,6 +77,7 @@ init_sram:
     LDA #$0000 : STA !sram_save_has_set_rng
     LDA #$0000 : STA !sram_preset_category
     LDA #$0000 : STA !sram_room_strat
+    LDA #$0000 : STA !sram_sprite_prio_flag
     
     LDA #!SRAM_VERSION : STA !sram_initialized
     RTS

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -16,6 +16,14 @@ macro cm_numfield(title, addr, start, end, increment, jsrtarget)
     db #$28, "<title>", #$FF
 endmacro
 
+macro cm_numfield_hex(title, addr, start, end, increment, jsrtarget)
+    dw !ACTION_NUMFIELD_HEX
+    dl <addr>
+    db <start>, <end>, <increment>
+    dw <jsrtarget>
+    db #$28, "<title>", #$FF
+endmacro
+
 macro cm_toggle(title, addr, value, jsrtarget)
     dw !ACTION_TOGGLE
     dl <addr>
@@ -819,7 +827,7 @@ misc_music_toggle:
     RTS
 
 misc_transparent:
-    %cm_toggle_bit("Samus on top", !ram_sprite_prio_flag, #$3000, #0)
+    %cm_toggle_bit("Samus on Top", !ram_sprite_prio_flag, #$3000, #0)
 
 misc_invincibility:
     %cm_toggle_bit("Invincibility", $7E0DE0, #$0007, #0)
@@ -999,6 +1007,7 @@ InfoHudMenu:
     dw #ih_room_strat
     dw #ih_room_counter
     dw #ih_lag
+    dw #ih_ram_watch
     dw #$0000
     %cm_header("INFOHUD")
 
@@ -1024,6 +1033,7 @@ DisplayModeMenu:
     dw ihmode_quickdrop
     dw ihmode_walljump
     dw ihmode_shottimer
+    dw ihmode_ramwatch
     dw #$0000
     %cm_header("INFOHUD DISPLAY MODE")
 
@@ -1081,6 +1091,9 @@ ihmode_walljump:
 ihmode_shottimer:
     %cm_jsr("Shot Timer", #action_select_infohud_mode, #$0011)
 
+ihmode_ramwatch:
+    %cm_jsr("RAM Watch", #action_select_infohud_mode, #$0012)
+
 action_select_infohud_mode:
 {
     TYA : STA !sram_display_mode
@@ -1112,6 +1125,7 @@ ih_display_mode:
     db #$28, " QUICK DROP", #$FF
     db #$28, "  WALL JUMP", #$FF
     db #$28, " SHOT TIMER", #$FF
+    db #$28, "  RAM WATCH", #$FF
     db #$FF
 
 ih_goto_room_strat:
@@ -1188,6 +1202,115 @@ ih_room_counter:
 
 ih_lag:
     %cm_numfield("Artificial lag", !sram_artificial_lag, 0, 64, 1, #0)
+
+ih_ram_watch:
+    %cm_submenu("Customize RAM Watch", #RAMWatchMenu)
+
+RAMWatchMenu:
+    dw ramwatch_left_hi
+    dw ramwatch_left_lo
+    dw ramwatch_left_edit_hi
+    dw ramwatch_left_edit_lo
+    dw ramwatch_execute_left
+    dw ramwatch_lock_left
+    dw ramwatch_right_hi
+    dw ramwatch_right_lo
+    dw ramwatch_right_edit_hi
+    dw ramwatch_right_edit_lo
+    dw ramwatch_execute_right
+    dw ramwatch_lock_right
+    dw #$0000
+    %cm_header("READ AND WRITE TO MEMORY")
+
+ramwatch_left_hi:
+    %cm_numfield_hex("Address 1 High", !ram_watch_left_hi, 0, 255, 1, #.routine)
+    .routine
+        XBA : ORA !ram_watch_left_lo
+        STA !ram_watch_left
+        RTS
+
+ramwatch_left_lo:
+    %cm_numfield_hex("Address 1 Low", !ram_watch_left_lo, 0, 255, 1, #.routine)
+    .routine
+        XBA : ORA !ram_watch_left_hi
+        XBA : STA !ram_watch_left
+        RTS
+
+ramwatch_left_edit_hi:
+    %cm_numfield_hex("Value 1 High", !ram_watch_edit_left_hi, 0, 255, 1, #.routine)
+    .routine
+        XBA : ORA !ram_watch_edit_left_lo
+        STA !ram_watch_edit_left
+        RTS
+
+ramwatch_left_edit_lo:
+    %cm_numfield_hex("Value 1 Low", !ram_watch_edit_left_lo, 0, 255, 1, #.routine)
+    .routine
+        XBA : ORA !ram_watch_edit_left_hi
+        XBA : STA !ram_watch_edit_left
+        RTS
+
+ramwatch_right_hi:
+    %cm_numfield_hex("Address 2 High", !ram_watch_right_hi, 0, 255, 1, #.routine)
+    .routine
+        XBA : ORA !ram_watch_right_lo
+        STA !ram_watch_right
+        RTS
+
+ramwatch_right_lo:
+    %cm_numfield_hex("Address 2 Low", !ram_watch_right_lo, 0, 255, 1, #.routine)
+    .routine
+        XBA : ORA !ram_watch_right_hi
+        XBA : STA !ram_watch_right
+        RTS
+
+ramwatch_right_edit_hi:
+    %cm_numfield_hex("Value 2 High", !ram_watch_edit_right_hi, 0, 255, 1, #.routine)
+    .routine
+        XBA : ORA !ram_watch_edit_right_lo
+        STA !ram_watch_edit_right
+        RTS
+
+ramwatch_right_edit_lo:
+    %cm_numfield_hex("Value 2 Low", !ram_watch_edit_right_lo, 0, 255, 1, #.routine)
+    .routine
+        XBA : ORA !ram_watch_edit_right_hi
+        XBA : STA !ram_watch_edit_right
+        RTS
+
+ramwatch_execute_left:
+    %cm_jsr("Write to Address 1", #action_ramwatch_edit_left, #$0000)
+
+ramwatch_execute_right:
+    %cm_jsr("Write to Address 2", #action_ramwatch_edit_right, #$0000)
+
+ramwatch_lock_left:
+    %cm_toggle("Lock Value 1", !ram_watch_edit_lock_left, #$0001, #action_HUD_ramwatch)
+
+ramwatch_lock_right:
+    %cm_toggle("Lock Value 2", !ram_watch_edit_lock_right, #$0001, #action_HUD_ramwatch)
+
+action_ramwatch_edit_left:
+{
+    LDA !ram_watch_left : TAX
+    LDA !ram_watch_edit_left : STA $7E0000,X
+    LDA #$0012 : STA !sram_display_mode
+    RTS
+}
+
+action_ramwatch_edit_right:
+{
+    LDA !ram_watch_right : TAX
+    LDA !ram_watch_edit_right : STA $7E0000,X
+    LDA #$0012 : STA !sram_display_mode
+    RTS
+}
+
+action_HUD_ramwatch:
+{
+    LDA #$0012 : STA !sram_display_mode
+    RTS
+}
 
 
 ; ----------

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -827,7 +827,7 @@ misc_music_toggle:
     RTS
 
 misc_transparent:
-    %cm_toggle_bit("Samus on Top", !ram_sprite_prio_flag, #$3000, #0)
+    %cm_toggle_bit("Samus on Top", !sram_sprite_prio_flag, #$3000, #0)
 
 misc_invincibility:
     %cm_toggle_bit("Invincibility", $7E0DE0, #$0007, #0)

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -146,7 +146,7 @@ MainMenu:
     dw #mm_goto_rngmenu
     dw #mm_goto_ctrlsmenu
     dw #$0000
-    %cm_header("SM PRACTICE HACK 2.2.2")
+    %cm_header("SM PRACTICE HACK 2.2.3")
 
 mm_goto_equipment:
     %cm_submenu("Equipment", #EquipmentMenu)

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -140,6 +140,9 @@ post_ceres_timers:
 
 preset_load_preset:
   PHB
+    LDA #$0000
+    STA $7E09D2 ; Current selected weapon
+    STA $7E0A04 ; Auto-cancel item
     LDA !sram_preset_category : ASL : TAX
     LDA.l preset_banks,X : %a8() : PHA : PLB : %a16()
 
@@ -161,8 +164,6 @@ preset_load_preset:
 
   .done
     LDA #$0000
-    STA $7E09D2 ; Current selected weapon
-    STA $7E0A04 ; Auto-cancel item
     STA $0795   ; "Currently transitioning"
     STA $0797   ; "Currently transitioning"
   PLB

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -105,6 +105,39 @@ reset_all_counters:
     RTL
 }
 
+startgame_seg_timer:
+{
+    ; seg timer will be 1:50 (1 second, 50 frames) behind by the time it appears
+    ; 20 frames more if the file was new
+    ; initializing to 1:50 for now
+    LDA #$0032 : STA !ram_seg_rt_frames
+    LDA #$0001 : STA !ram_seg_rt_seconds
+    LDA #$0000 : STA !ram_seg_rt_minutes
+    JSL $808924    ; overwritten code
+    RTL
+}
+
+post_ceres_timers:
+{   ; don't reset segment timer after Ceres
+    LDA #$0000
+    STA $12 : STA $14
+    STA !ram_room_has_set_rng
+    STA $09DA : STA $09DC : STA $09DE : STA $09E0
+    STA !ram_realtime_room : STA !ram_last_realtime_room
+    STA !ram_gametime_room : STA !ram_last_gametime_room
+    STA !ram_last_room_lag : STA !ram_last_door_lag_frames : STA !ram_transition_counter
+
+    ; adding 1:13 to seg timer to account for missed frames between Ceres and Zebes
+    LDA !ram_seg_rt_frames : CLC : ADC #$000D : STA !ram_seg_rt_frames : CMP #$003C : BMI +
+    SEC : SBC #$003C : STA !ram_seg_rt_frames : INC $12
++   LDA !ram_seg_rt_seconds : CLC : ADC #$0001 : ADC $12 : STA !ram_seg_rt_seconds : CMP #$003C : BMI +
+    SEC : SBC #$003C : STA !ram_seg_rt_seconds : INC $14
++   LDA $14 : BEQ .done : CLC : ADC !ram_seg_rt_minutes : STA !ram_seg_rt_minutes
+
+  .done
+    RTL
+}
+
 preset_load_preset:
   PHB
     LDA !sram_preset_category : ASL : TAX

--- a/src/presets/100early_data.asm
+++ b/src/presets/100early_data.asm
@@ -29,6 +29,7 @@ preset_100early_crateria_ceres_elevator:
     dl $7E09CC : db $02 : dw $0000 ; Max supers
     dl $7E09CE : db $02 : dw $0000 ; Pbs
     dl $7E09D0 : db $02 : dw $0000 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E09D4 : db $02 : dw $0000 ; Max reserves
     dl $7E09D6 : db $02 : dw $0000 ; Reserves
     dl $7E0A1C : db $02 : dw $0000 ; Samus position/state
@@ -1254,6 +1255,7 @@ preset_100early_red_tower_and_crateria_beta_power_bombs:
     dl $7E0913 : db $02 : dw $5400 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $02FB ; Screen Y position in pixels
     dl $7E09C2 : db $02 : dw $0177 ; Health
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0004 ; More position/state
     dl $7E0AF6 : db $02 : dw $0061 ; Samus X
@@ -1279,6 +1281,7 @@ preset_100early_red_tower_and_crateria_crateria_kihunters:
     dl $7E09CA : db $02 : dw $0005 ; Supers
     dl $7E09CE : db $02 : dw $000B ; Pbs
     dl $7E09D0 : db $02 : dw $000F ; Max pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $006A ; Samus X
@@ -1302,6 +1305,7 @@ preset_100early_red_tower_and_crateria_oceanfly:
     dl $7E090F : db $02 : dw $E401 ; Screen subpixel X position.
     dl $7E0913 : db $02 : dw $B800 ; Screen subpixel Y position
     dl $7E09CE : db $02 : dw $000A ; Pbs
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $0025 ; Samus X
     dl $7E0AFA : db $02 : dw $008B ; Samus Y
     dl $7ED8B0 : db $02 : dw $2000 ; Events, Items, Doors
@@ -1314,6 +1318,7 @@ preset_100early_red_tower_and_crateria_the_moat:
     dl $7E0911 : db $02 : dw $0200 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $F400 ; Screen subpixel Y position
     dl $7E09C2 : db $02 : dw $0172 ; Health
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $02B1 ; Samus X
     dw #$FFFF
 .after
@@ -2156,6 +2161,7 @@ preset_100early_maridia_predraygon_aqueduct:
     dl $7E0913 : db $02 : dw $FC00 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0300 ; Screen Y position in pixels
     dl $7E09CA : db $02 : dw $0018 ; Supers
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $01B0 ; Samus X
     dl $7E0AFA : db $02 : dw $038B ; Samus Y
     dl $7ED8C0 : db $02 : dw $CB7C ; Events, Items, Doors
@@ -2177,6 +2183,7 @@ preset_100early_maridia_predraygon_botwoon:
     dl $7E0913 : db $02 : dw $F800 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0001 ; Screen Y position in pixels
     dl $7E09CE : db $02 : dw $000B ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $03A8 ; Samus X
     dl $7E0AFA : db $02 : dw $008B ; Samus Y
     dl $7ED91A : db $02 : dw $0075 ; Events, Items, Doors

--- a/src/presets/100early_data.asm
+++ b/src/presets/100early_data.asm
@@ -3558,8 +3558,8 @@ preset_100early_tourian_escape_room_3:
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0A76 : db $02 : dw $8000 ; Hyper beam
-    dl $7E0AF6 : db $02 : dw $00DB ; Samus X
-    dl $7E0AFA : db $02 : dw $01BB ; Samus Y
+    dl $7E0AF6 : db $02 : dw $00DF ; Samus X
+    dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dl $7ED820 : db $02 : dw $7FCD ; Events, Items, Doors
     dl $7ED82C : db $02 : dw $0203 ; Events, Items, Doors
     dw #$FFFF

--- a/src/presets/14ice_data.asm
+++ b/src/presets/14ice_data.asm
@@ -1607,8 +1607,8 @@ preset_14ice_tourian_escape_room_3:
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0A76 : db $02 : dw $8000 ; Hyper beam
-    dl $7E0AF6 : db $02 : dw $00DB ; Samus X
-    dl $7E0AFA : db $02 : dw $01BB ; Samus Y
+    dl $7E0AF6 : db $02 : dw $00DF ; Samus X
+    dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dl $7ED820 : db $02 : dw $4FC5 ; Events, Items, Doors
     dl $7ED82C : db $02 : dw $0203 ; Events, Items, Doors
     dw #$FFFF

--- a/src/presets/14ice_data.asm
+++ b/src/presets/14ice_data.asm
@@ -29,6 +29,7 @@ preset_14ice_crateria_ceres_elevator:
     dl $7E09CC : db $02 : dw $0000 ; Max supers
     dl $7E09CE : db $02 : dw $0000 ; Pbs
     dl $7E09D0 : db $02 : dw $0000 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E09D4 : db $02 : dw $0000 ; Max reserves
     dl $7E09D6 : db $02 : dw $0000 ; Reserves
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
@@ -467,6 +468,7 @@ preset_14ice_brinstar_leaving_power_bombs:
     dl $7E09C2 : db $02 : dw $00AD ; Health
     dl $7E09CA : db $02 : dw $0003 ; Supers
     dl $7E09CE : db $02 : dw $0005 ; Pbs
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E09D0 : db $02 : dw $0005 ; Max pbs
     dl $7E0AF6 : db $02 : dw $0157 ; Samus X
     dl $7E0AFA : db $02 : dw $00AB ; Samus Y
@@ -531,6 +533,7 @@ preset_14ice_brinstar_ocean:
     dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
     dl $7E09C6 : db $02 : dw $0007 ; Missiles
     dl $7E09C8 : db $02 : dw $000A ; Max missiles
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $01A1 ; Samus X
     dl $7ED870 : db $02 : dw $0190 ; Events, Items, Doors
     dl $7ED91A : db $02 : dw $0013 ; Events, Items, Doors
@@ -729,6 +732,7 @@ preset_14ice_brinstar_revisit_breaking_tube:
     dl $7E09C2 : db $02 : dw $0052 ; Health
     dl $7E09C6 : db $02 : dw $0008 ; Missiles
     dl $7E09CA : db $02 : dw $000A ; Supers
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $002C ; Samus X
@@ -745,6 +749,7 @@ preset_14ice_brinstar_revisit_entering_kraids_lair:
     dl $7E0913 : db $02 : dw $1801 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0100 ; Screen Y position in pixels
     dl $7E09CE : db $02 : dw $0001 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $002E ; Samus X
     dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dl $7ED820 : db $02 : dw $0801 ; Events, Items, Doors
@@ -956,6 +961,7 @@ preset_14ice_lower_norfair_ln_main_hall:
     dl $7E0915 : db $02 : dw $0200 ; Screen Y position in pixels
     dl $7E09C2 : db $02 : dw $00F7 ; Health
     dl $7E09C6 : db $02 : dw $0007 ; Missiles
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $009B ; Samus position/state
     dl $7E0A1E : db $02 : dw $0000 ; More position/state
     dl $7E0AF6 : db $02 : dw $0480 ; Samus X
@@ -1007,6 +1013,7 @@ preset_14ice_lower_norfair_amphitheatre:
     dl $7E09C6 : db $02 : dw $0006 ; Missiles
     dl $7E09CA : db $02 : dw $0006 ; Supers
     dl $7E09CE : db $02 : dw $0002 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $00B0 ; Samus X
     dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dw #$FFFF

--- a/src/presets/14speed_data.asm
+++ b/src/presets/14speed_data.asm
@@ -29,6 +29,7 @@ preset_14speed_crateria_ceres_elevator:
     dl $7E09CC : db $02 : dw $0000 ; Max supers
     dl $7E09CE : db $02 : dw $0000 ; Pbs
     dl $7E09D0 : db $02 : dw $0000 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E09D4 : db $02 : dw $0000 ; Max reserves
     dl $7E09D6 : db $02 : dw $0000 ; Reserves
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
@@ -468,6 +469,7 @@ preset_14speed_brinstar_leaving_power_bombs:
     dl $7E09CA : db $02 : dw $0003 ; Supers
     dl $7E09CE : db $02 : dw $0005 ; Pbs
     dl $7E09D0 : db $02 : dw $0005 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $0157 ; Samus X
     dl $7E0AFA : db $02 : dw $00AB ; Samus Y
     dl $7ED874 : db $02 : dw $0104 ; Events, Items, Doors
@@ -531,6 +533,7 @@ preset_14speed_brinstar_ocean:
     dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
     dl $7E09C6 : db $02 : dw $0007 ; Missiles
     dl $7E09C8 : db $02 : dw $000A ; Max missiles
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $01A1 ; Samus X
     dl $7ED870 : db $02 : dw $0190 ; Events, Items, Doors
     dl $7ED91A : db $02 : dw $0013 ; Events, Items, Doors
@@ -729,6 +732,7 @@ preset_14speed_brinstar_revisit_breaking_tube:
     dl $7E09C2 : db $02 : dw $0052 ; Health
     dl $7E09C6 : db $02 : dw $0008 ; Missiles
     dl $7E09CA : db $02 : dw $000A ; Supers
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $002C ; Samus X
@@ -745,6 +749,7 @@ preset_14speed_brinstar_revisit_entering_kraids_lair:
     dl $7E0913 : db $02 : dw $1801 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0100 ; Screen Y position in pixels
     dl $7E09CE : db $02 : dw $0001 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $002E ; Samus X
     dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dl $7ED820 : db $02 : dw $0801 ; Events, Items, Doors
@@ -946,6 +951,7 @@ preset_14speed_lower_norfair_ln_main_hall:
     dl $7E0911 : db $02 : dw $0400 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
     dl $7E09C2 : db $02 : dw $00D7 ; Health
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $009B ; Samus position/state
     dl $7E0A1E : db $02 : dw $0000 ; More position/state
     dl $7E0AF6 : db $02 : dw $0480 ; Samus X
@@ -995,6 +1001,7 @@ preset_14speed_lower_norfair_amphitheatre:
     dl $7E09C6 : db $02 : dw $0005 ; Missiles
     dl $7E09CA : db $02 : dw $0006 ; Supers
     dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $00B3 ; Samus X
     dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dw #$FFFF
@@ -1249,6 +1256,7 @@ preset_14speed_maridia_aqueduct:
     dl $7E0915 : db $02 : dw $0300 ; Screen Y position in pixels
     dl $7E09C2 : db $02 : dw $00C3 ; Health
     dl $7E09CA : db $02 : dw $0009 ; Supers
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $001D ; Samus position/state
     dl $7E0A1E : db $02 : dw $0408 ; More position/state
     dl $7E0AF6 : db $02 : dw $01BD ; Samus X
@@ -1271,6 +1279,7 @@ preset_14speed_maridia_botwoon:
     dl $7E0913 : db $02 : dw $73FF ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0013 ; Screen Y position in pixels
     dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $03AD ; Samus X

--- a/src/presets/14speed_data.asm
+++ b/src/presets/14speed_data.asm
@@ -1622,7 +1622,8 @@ preset_14speed_tourian_escape_room_3:
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0A76 : db $02 : dw $8000 ; Hyper beam
-    dl $7E0AFA : db $02 : dw $01BB ; Samus Y
+    dl $7E0AF6 : db $02 : dw $00DF ; Samus X
+    dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dl $7ED820 : db $02 : dw $4FC5 ; Events, Items, Doors
     dl $7ED82C : db $02 : dw $0203 ; Events, Items, Doors
     dw #$FFFF

--- a/src/presets/allbosskpdr_data.asm
+++ b/src/presets/allbosskpdr_data.asm
@@ -1893,8 +1893,8 @@ preset_allbosskpdr_tourian_escape_room_3:
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0A76 : db $02 : dw $8000 ; Hyper beam
-    dl $7E0AF6 : db $02 : dw $00DB ; Samus X
-    dl $7E0AFA : db $02 : dw $01BB ; Samus Y
+    dl $7E0AF6 : db $02 : dw $00DF ; Samus X
+    dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dl $7ED820 : db $02 : dw $4FC5 ; Events, Items, Doors
     dl $7ED82C : db $02 : dw $0203 ; Events, Items, Doors
     dw #$FFFF

--- a/src/presets/allbosskpdr_data.asm
+++ b/src/presets/allbosskpdr_data.asm
@@ -29,6 +29,7 @@ preset_allbosskpdr_crateria_ceres_elevator:
     dl $7E09CC : db $02 : dw $0000 ; Max supers
     dl $7E09CE : db $02 : dw $0000 ; Pbs
     dl $7E09D0 : db $02 : dw $0000 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E09D4 : db $02 : dw $0000 ; Max reserves
     dl $7E09D6 : db $02 : dw $0000 ; Reserves
     dl $7E0A1C : db $02 : dw $0000 ; Samus position/state
@@ -816,6 +817,7 @@ preset_allbosskpdr_wrecked_ship_leaving_power_bombs:
     dl $7E09CA : db $02 : dw $0004 ; Supers
     dl $7E09CE : db $02 : dw $0005 ; Pbs
     dl $7E09D0 : db $02 : dw $0005 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $0157 ; Samus X
     dl $7E0AFA : db $02 : dw $00AB ; Samus Y
     dl $7ED874 : db $02 : dw $0104 ; Events, Items, Doors
@@ -865,6 +867,7 @@ preset_allbosskpdr_wrecked_ship_entering_wrecked_ship:
     dl $7E09C2 : db $02 : dw $0082 ; Health
     dl $7E09CA : db $02 : dw $0003 ; Supers
     dl $7E09CE : db $02 : dw $0002 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $07DB ; Samus X
@@ -1043,6 +1046,7 @@ preset_allbosskpdr_maridia_breaking_tube:
     dl $7E0915 : db $02 : dw $0100 ; Screen Y position in pixels
     dl $7E09C2 : db $02 : dw $0090 ; Health
     dl $7E09CA : db $02 : dw $000A ; Supers
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $01AD ; Samus X
@@ -1066,6 +1070,7 @@ preset_allbosskpdr_maridia_mt_everest:
     dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0004 ; Screen Y position in pixels
     dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0004 ; More position/state
     dl $7E0AF6 : db $02 : dw $00C8 ; Samus X
@@ -1392,6 +1397,7 @@ preset_allbosskpdr_lower_norfair_ln_main_hall:
     dl $7E0915 : db $02 : dw $0200 ; Screen Y position in pixels
     dl $7E09C2 : db $02 : dw $0162 ; Health
     dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0026 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0E08 ; More position/state
     dl $7E0AF6 : db $02 : dw $0480 ; Samus X
@@ -1408,6 +1414,7 @@ preset_allbosskpdr_lower_norfair_green_gate_glitch:
     dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $9400 ; Screen subpixel Y position
     dl $7E09CE : db $02 : dw $0005 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0004 ; More position/state
     dl $7E0AF6 : db $02 : dw $0025 ; Samus X

--- a/src/presets/allbosspkdr_data.asm
+++ b/src/presets/allbosspkdr_data.asm
@@ -29,6 +29,7 @@ preset_allbosspkdr_crateria_ceres_elevator:
     dl $7E09CC : db $02 : dw $0000 ; Max supers
     dl $7E09CE : db $02 : dw $0000 ; Pbs
     dl $7E09D0 : db $02 : dw $0000 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E09D4 : db $02 : dw $0000 ; Max reserves
     dl $7E09D6 : db $02 : dw $0000 ; Reserves
     dl $7E0A1C : db $02 : dw $0000 ; Samus position/state
@@ -538,6 +539,7 @@ preset_allbosspkdr_brinstar_leaving_power_bombs:
     dl $7E09CA : db $02 : dw $0003 ; Supers
     dl $7E09CE : db $02 : dw $0005 ; Pbs
     dl $7E09D0 : db $02 : dw $0005 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $02C1 ; Samus X
     dl $7ED874 : db $02 : dw $0104 ; Events, Items, Doors
     dl $7ED8B6 : db $02 : dw $2008 ; Events, Items, Doors
@@ -581,6 +583,7 @@ preset_allbosspkdr_brinstar_moat:
     dl $7E0911 : db $02 : dw $0200 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $EC00 ; Screen subpixel Y position
     dl $7E09CE : db $02 : dw $0001 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0089 ; Samus position/state
     dl $7E0A1E : db $02 : dw $1508 ; More position/state
     dl $7E0AF6 : db $02 : dw $02DB ; Samus X
@@ -803,6 +806,7 @@ preset_allbosspkdr_wrecked_ship_breaking_tube:
     dl $7E090F : db $02 : dw $8000 ; Screen subpixel X position.
     dl $7E0913 : db $02 : dw $8C00 ; Screen subpixel Y position
     dl $7E09C2 : db $02 : dw $004D ; Health
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $002C ; Samus X
@@ -823,6 +827,7 @@ preset_allbosspkdr_upper_norfair_business_center:
     dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0238 ; Screen Y position in pixels
     dl $7E09CE : db $02 : dw $0003 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $009B ; Samus position/state
     dl $7E0A1E : db $02 : dw $0000 ; More position/state
     dl $7E0AF6 : db $02 : dw $0080 ; Samus X
@@ -1418,6 +1423,7 @@ preset_allbosspkdr_lower_norfair_ln_main_hall:
     dl $7E0915 : db $02 : dw $0200 ; Screen Y position in pixels
     dl $7E09C2 : db $02 : dw $0172 ; Health
     dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $009B ; Samus position/state
     dl $7E0A1E : db $02 : dw $0000 ; More position/state
     dl $7E0AF6 : db $02 : dw $0480 ; Samus X
@@ -1435,6 +1441,7 @@ preset_allbosspkdr_lower_norfair_green_gate_glitch:
     dl $7E0913 : db $02 : dw $2C00 ; Screen subpixel Y position
     dl $7E09C2 : db $02 : dw $0186 ; Health
     dl $7E09CE : db $02 : dw $0005 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0004 ; More position/state
     dl $7E0AF6 : db $02 : dw $006D ; Samus X

--- a/src/presets/allbosspkdr_data.asm
+++ b/src/presets/allbosspkdr_data.asm
@@ -1926,8 +1926,8 @@ preset_allbosspkdr_tourian_escape_room_3:
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0A76 : db $02 : dw $8000 ; Hyper beam
-    dl $7E0AF6 : db $02 : dw $00DB ; Samus X
-    dl $7E0AFA : db $02 : dw $01BB ; Samus Y
+    dl $7E0AF6 : db $02 : dw $00DF ; Samus X
+    dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dl $7ED820 : db $02 : dw $4FC5 ; Events, Items, Doors
     dl $7ED82C : db $02 : dw $0203 ; Events, Items, Doors
     dw #$FFFF

--- a/src/presets/allbossprkd_data.asm
+++ b/src/presets/allbossprkd_data.asm
@@ -1958,8 +1958,8 @@ preset_allbossprkd_tourian_escape_room_3:
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0A76 : db $02 : dw $8000 ; Hyper beam
-    dl $7E0AF6 : db $02 : dw $00DB ; Samus X
-    dl $7E0AFA : db $02 : dw $01BB ; Samus Y
+    dl $7E0AF6 : db $02 : dw $00DF ; Samus X
+    dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dl $7ED820 : db $02 : dw $4FC5 ; Events, Items, Doors
     dl $7ED82C : db $02 : dw $0203 ; Events, Items, Doors
     dw #$FFFF

--- a/src/presets/allbossprkd_data.asm
+++ b/src/presets/allbossprkd_data.asm
@@ -29,6 +29,7 @@ preset_allbossprkd_crateria_ceres_elevator:
     dl $7E09CC : db $02 : dw $0000 ; Max supers
     dl $7E09CE : db $02 : dw $0000 ; Pbs
     dl $7E09D0 : db $02 : dw $0000 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E09D4 : db $02 : dw $0000 ; Max reserves
     dl $7E09D6 : db $02 : dw $0000 ; Reserves
     dl $7E0A1C : db $02 : dw $0000 ; Samus position/state
@@ -603,6 +604,7 @@ preset_allbossprkd_brinstar_leaving_power_bombs:
     dl $7E09CA : db $02 : dw $0008 ; Supers
     dl $7E09CE : db $02 : dw $0005 ; Pbs
     dl $7E09D0 : db $02 : dw $0005 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $02BE ; Samus X
     dl $7ED874 : db $02 : dw $0104 ; Events, Items, Doors
     dl $7ED8B6 : db $02 : dw $2028 ; Events, Items, Doors
@@ -623,6 +625,7 @@ preset_allbossprkd_wrecked_ship_moat:
     dl $7E0913 : db $02 : dw $6800 ; Screen subpixel Y position
     dl $7E09CA : db $02 : dw $000A ; Supers
     dl $7E09CE : db $02 : dw $0001 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0089 ; Samus position/state
     dl $7E0A1E : db $02 : dw $1508 ; More position/state
     dl $7E0AF6 : db $02 : dw $02DB ; Samus X
@@ -843,6 +846,7 @@ preset_allbossprkd_wrecked_ship_breaking_tube:
     dl $7E0913 : db $02 : dw $D000 ; Screen subpixel Y position
     dl $7E09A6 : db $02 : dw $1004 ; Beams
     dl $7E09A8 : db $02 : dw $1004 ; Beams
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $002D ; Samus X
@@ -867,6 +871,7 @@ preset_allbossprkd_upper_norfair_business_center:
     dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0238 ; Screen Y position in pixels
     dl $7E09CE : db $02 : dw $0003 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $009B ; Samus position/state
     dl $7E0A1E : db $02 : dw $0000 ; More position/state
     dl $7E0AF6 : db $02 : dw $0080 ; Samus X
@@ -1098,6 +1103,7 @@ preset_allbossprkd_lower_norfair_ln_main_hall:
     dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
     dl $7E09A6 : db $02 : dw $1001 ; Beams
     dl $7E09C2 : db $02 : dw $00C6 ; Health
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $009B ; Samus position/state
     dl $7E0A1E : db $02 : dw $0000 ; More position/state
     dl $7E0AF6 : db $02 : dw $0480 ; Samus X
@@ -1112,6 +1118,7 @@ preset_allbossprkd_lower_norfair_green_gate_glitch:
     dl $7E090F : db $02 : dw $4000 ; Screen subpixel X position.
     dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $AC00 ; Screen subpixel Y position
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0004 ; More position/state
     dl $7E0AF6 : db $02 : dw $007C ; Samus X
@@ -1601,6 +1608,7 @@ preset_allbossprkd_maridia_aqueduct:
     dl $7E0915 : db $02 : dw $0300 ; Screen Y position in pixels
     dl $7E09C2 : db $02 : dw $0154 ; Health
     dl $7E09CA : db $02 : dw $000E ; Supers
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $001D ; Samus position/state
     dl $7E0A1E : db $02 : dw $0408 ; More position/state
     dl $7E0AF6 : db $02 : dw $01B6 ; Samus X
@@ -1623,6 +1631,7 @@ preset_allbossprkd_maridia_botwoon:
     dl $7E0913 : db $02 : dw $F400 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
     dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $03A6 ; Samus X

--- a/src/presets/gtclassic_data.asm
+++ b/src/presets/gtclassic_data.asm
@@ -29,6 +29,7 @@ preset_gtclassic_crateria_ship:
     dl $7E09CC : db $02 : dw $0000 ; Max supers
     dl $7E09CE : db $02 : dw $0000 ; Pbs
     dl $7E09D0 : db $02 : dw $0000 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E09D4 : db $02 : dw $0000 ; Max reserves
     dl $7E09D6 : db $02 : dw $0000 ; Reserves
     dl $7E0A1C : db $02 : dw $0000 ; Samus position/state
@@ -664,6 +665,7 @@ preset_gtclassic_brinstar_caterpillars_up:
     dl $7E09C2 : db $02 : dw $0093 ; Health
     dl $7E09CE : db $02 : dw $0005 ; Pbs
     dl $7E09D0 : db $02 : dw $0005 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $02B1 ; Samus X
@@ -683,6 +685,7 @@ preset_gtclassic_brinstar_reverse_hellway:
     dl $7E0913 : db $02 : dw $5400 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0500 ; Screen Y position in pixels
     dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0004 ; More position/state
     dl $7E0AF6 : db $02 : dw $004C ; Samus X
@@ -744,6 +747,7 @@ preset_gtclassic_brinstar_breaking_tube:
     dl $7E0913 : db $02 : dw $1400 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0100 ; Screen Y position in pixels
     dl $7E09CA : db $02 : dw $0004 ; Supers
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $01B7 ; Samus X
     dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dw #$FFFF
@@ -762,6 +766,7 @@ preset_gtclassic_kraid_entering_kraids_lair:
     dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $6400 ; Screen subpixel Y position
     dl $7E09CE : db $02 : dw $0003 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $002E ; Samus X
     dl $7ED820 : db $02 : dw $0801 ; Events, Items, Doors
     dw #$FFFF
@@ -1033,6 +1038,7 @@ preset_gtclassic_bootless_upper_norfair_ln_main_hall:
     dl $7E0911 : db $02 : dw $0400 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
     dl $7E09C2 : db $02 : dw $001F ; Health
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $009B ; Samus position/state
     dl $7E0A1E : db $02 : dw $0000 ; More position/state
     dl $7E0AF6 : db $02 : dw $0480 ; Samus X
@@ -1062,6 +1068,7 @@ preset_gtclassic_bootless_upper_norfair_green_gate_glitch:
     dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $4000 ; Screen subpixel Y position
     dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0004 ; More position/state
     dl $7E0AF6 : db $02 : dw $006E ; Samus X
@@ -1751,6 +1758,7 @@ preset_gtclassic_maridia_aqueduct:
     dl $7E0911 : db $02 : dw $0008 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $5400 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0300 ; Screen Y position in pixels
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $007C ; Samus X
     dl $7E0AFA : db $02 : dw $03AB ; Samus Y
     dw #$FFFF
@@ -1771,6 +1779,7 @@ preset_gtclassic_maridia_botwoon_hallway:
     dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
     dl $7E09CA : db $02 : dw $0013 ; Supers
     dl $7E09CE : db $02 : dw $000D ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0004 ; More position/state
     dl $7E0AF6 : db $02 : dw $0092 ; Samus X

--- a/src/presets/gtclassic_data.asm
+++ b/src/presets/gtclassic_data.asm
@@ -978,6 +978,7 @@ preset_gtclassic_bootless_upper_norfair_bubble_mountain:
     dl $7E0913 : db $02 : dw $5000 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
     dl $7E09C2 : db $02 : dw $0121 ; Health
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $04B1 ; Samus X
     dl $7E0AFA : db $02 : dw $008B ; Samus Y
     dw #$FFFF
@@ -993,6 +994,7 @@ preset_gtclassic_bootless_upper_norfair_magdollite_tunnel:
     dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $01F5 ; Screen Y position in pixels
     dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $0056 ; Samus X
     dl $7E0AFA : db $02 : dw $028B ; Samus Y
     dl $7ED91A : db $02 : dw $0018 ; Events, Items, Doors
@@ -1227,6 +1229,7 @@ preset_gtclassic_hi_jump_upper_norfair_bubble_mountain:
     dl $7E0913 : db $02 : dw $1000 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
     dl $7E09C2 : db $02 : dw $0101 ; Health
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $04B8 ; Samus X
     dl $7E0AFA : db $02 : dw $008B ; Samus Y
     dw #$FFFF
@@ -1245,6 +1248,7 @@ preset_gtclassic_hi_jump_upper_norfair_magdollite_tunnel:
     dl $7E09C6 : db $02 : dw $0005 ; Missiles
     dl $7E09CA : db $02 : dw $0005 ; Supers
     dl $7E09CE : db $02 : dw $0003 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $00AB ; Samus X
     dl $7E0AFA : db $02 : dw $028B ; Samus Y
     dl $7ED91A : db $02 : dw $001C ; Events, Items, Doors
@@ -1291,6 +1295,7 @@ preset_gtclassic_hi_jump_upper_norfair_ln_main_hall:
     dl $7E0911 : db $02 : dw $0400 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
     dl $7E09C2 : db $02 : dw $009C ; Health
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $009B ; Samus position/state
     dl $7E0A1E : db $02 : dw $0000 ; More position/state
     dl $7E0AF6 : db $02 : dw $0480 ; Samus X
@@ -1320,6 +1325,7 @@ preset_gtclassic_hi_jump_upper_norfair_green_gate_glitch:
     dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $4000 ; Screen subpixel Y position
     dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0004 ; More position/state
     dl $7E0AF6 : db $02 : dw $0074 ; Samus X
@@ -2376,7 +2382,7 @@ preset_gtclassic_tourian_escape_room_3:
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0A76 : db $02 : dw $8000 ; Hyper beam
-    dl $7E0AF6 : db $02 : dw $00DC ; Samus X
+    dl $7E0AF6 : db $02 : dw $00DF ; Samus X
     dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dl $7ED820 : db $02 : dw $4FCD ; Events, Items, Doors
     dl $7ED82C : db $02 : dw $0203 ; Events, Items, Doors

--- a/src/presets/hundo_data.asm
+++ b/src/presets/hundo_data.asm
@@ -29,6 +29,7 @@ preset_hundo_bombs_ceres_elevator:
     dl $7E09CC : db $02 : dw $0000 ; Max supers
     dl $7E09CE : db $02 : dw $0000 ; Pbs
     dl $7E09D0 : db $02 : dw $0000 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E09D4 : db $02 : dw $0000 ; Max reserves
     dl $7E09D6 : db $02 : dw $0000 ; Reserves
     dl $7E0A1C : db $02 : dw $0000 ; Samus position/state
@@ -1139,6 +1140,7 @@ preset_hundo_phantoon_leaving_alpha_pbs:
     dl $7E09CA : db $02 : dw $0004 ; Supers
     dl $7E09CE : db $02 : dw $0004 ; Pbs
     dl $7E09D0 : db $02 : dw $0005 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $000B ; Samus position/state
     dl $7E0AF6 : db $02 : dw $02C0 ; Samus X
     dl $7ED874 : db $02 : dw $0F04 ; Events, Items, Doors
@@ -1187,6 +1189,7 @@ preset_hundo_phantoon_ocean_fly:
     dl $7E0911 : db $02 : dw $0131 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $8800 ; Screen subpixel Y position
     dl $7E09C6 : db $02 : dw $0028 ; Missiles
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0011 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0108 ; More position/state
     dl $7E0A68 : db $02 : dw $00AD ; Flash suit
@@ -2048,6 +2051,7 @@ preset_hundo_draygon_aqueduct:
     dl $7E0913 : db $02 : dw $1BFF ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0300 ; Screen Y position in pixels
     dl $7E09CA : db $02 : dw $0011 ; Supers
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0027 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0508 ; More position/state
     dl $7E0AF6 : db $02 : dw $01B3 ; Samus X
@@ -2071,6 +2075,7 @@ preset_hundo_draygon_botwoon:
     dl $7E0913 : db $02 : dw $1400 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $000D ; Screen Y position in pixels
     dl $7E09CE : db $02 : dw $000F ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0051 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0208 ; More position/state
     dl $7E0AF6 : db $02 : dw $03DA ; Samus X

--- a/src/presets/kpdr21_data.asm
+++ b/src/presets/kpdr21_data.asm
@@ -29,6 +29,7 @@ preset_kpdr21_crateria_ship:
     dl $7E09CC : db $02 : dw $0000 ; Max supers
     dl $7E09CE : db $02 : dw $0000 ; Pbs
     dl $7E09D0 : db $02 : dw $0000 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E09D4 : db $02 : dw $0000 ; Max reserves
     dl $7E09D6 : db $02 : dw $0000 ; Reserves
     dl $7E0A1C : db $02 : dw $0000 ; Samus position/state
@@ -1142,6 +1143,8 @@ preset_kpdr21_red_brinstar_caterpillars_up:
     dl $7E09C2 : db $02 : dw $010F ; Health
     dl $7E09CE : db $02 : dw $0005 ; Pbs
     dl $7E09D0 : db $02 : dw $0005 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $02AF ; Samus X
@@ -1187,6 +1190,8 @@ preset_kpdr21_wrecked_ship_oceanfly_setup:
     dl $7E090F : db $02 : dw $8C00 ; Screen subpixel X position.
     dl $7E0913 : db $02 : dw $3000 ; Screen subpixel Y position
     dl $7E09CE : db $02 : dw $0002 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $002C ; Samus X
@@ -1532,6 +1537,7 @@ preset_kpdr21_maridia_breaking_tube:
     dl $7E07C3 : db $02 : dw $B130 ; GFX Pointers
     dl $7E07C5 : db $02 : dw $3CBE ; GFX Pointers
     dl $7E07C7 : db $02 : dw $C2B8 ; GFX Pointers
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E090F : db $02 : dw $E000 ; Screen subpixel X position.
     dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $7400 ; Screen subpixel Y position
@@ -1552,6 +1558,7 @@ preset_kpdr21_maridia_fish_tank:
     dl $7E0913 : db $02 : dw $C000 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $05F4 ; Screen Y position in pixels
     dl $7E09CE : db $02 : dw $0002 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $0167 ; Samus X
     dl $7E0AFA : db $02 : dw $068B ; Samus Y
     dl $7ED820 : db $02 : dw $0801 ; Events, Items, Doors
@@ -1595,6 +1602,7 @@ preset_kpdr21_maridia_aqueduct:
     dl $7E0913 : db $02 : dw $83FF ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0300 ; Screen Y position in pixels
     dl $7E09CA : db $02 : dw $0009 ; Supers
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $01AD ; Samus X
     dl $7E0AFA : db $02 : dw $038B ; Samus Y
     dl $7ED8C0 : db $02 : dw $8174 ; Events, Items, Doors
@@ -1615,6 +1623,7 @@ preset_kpdr21_maridia_botwoon_hallway:
     dl $7E0913 : db $02 : dw $4000 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
     dl $7E09CE : db $02 : dw $0001 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0004 ; More position/state
     dl $7E0AF6 : db $02 : dw $009D ; Samus X
@@ -2033,6 +2042,7 @@ preset_kpdr21_lower_norfair_ln_main_hall:
     dl $7E0915 : db $02 : dw $0200 ; Screen Y position in pixels
     dl $7E09C2 : db $02 : dw $00BA ; Health
     dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $009B ; Samus position/state
     dl $7E0A1E : db $02 : dw $0000 ; More position/state
     dl $7E0AF6 : db $02 : dw $0480 ; Samus X
@@ -2082,6 +2092,7 @@ preset_kpdr21_lower_norfair_amphitheatre:
     dl $7E0915 : db $02 : dw $011D ; Screen Y position in pixels
     dl $7E09C2 : db $02 : dw $0084 ; Health
     dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $00A7 ; Samus X
     dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dw #$FFFF

--- a/src/presets/kpdr21_data.asm
+++ b/src/presets/kpdr21_data.asm
@@ -2655,7 +2655,7 @@ preset_kpdr21_tourian_escape_room_3:
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0A76 : db $02 : dw $8000 ; Hyper beam
-    dl $7E0AF6 : db $02 : dw $00DC ; Samus X
+    dl $7E0AF6 : db $02 : dw $00DF ; Samus X
     dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dl $7ED820 : db $02 : dw $4FC5 ; Events, Items, Doors
     dl $7ED82C : db $02 : dw $0203 ; Events, Items, Doors

--- a/src/presets/kpdr25_data.asm
+++ b/src/presets/kpdr25_data.asm
@@ -29,6 +29,7 @@ preset_kpdr25_bombs_ceres_elevator:
     dl $7E09CC : db $02 : dw $0000 ; Max supers
     dl $7E09CE : db $02 : dw $0000 ; Pbs
     dl $7E09D0 : db $02 : dw $0000 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E09D4 : db $02 : dw $0000 ; Max reserves
     dl $7E09D6 : db $02 : dw $0000 ; Reserves
     dl $7E0A1C : db $02 : dw $0026 ; Samus position/state
@@ -764,6 +765,7 @@ preset_kpdr25_wrecked_ship_post_power_bombs:
     dl $7E09CA : db $02 : dw $0002 ; Supers
     dl $7E09CE : db $02 : dw $0005 ; Pbs
     dl $7E09D0 : db $02 : dw $0005 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $000B ; Samus position/state
     dl $7E0AF6 : db $02 : dw $02CA ; Samus X
     dl $7ED874 : db $02 : dw $0D04 ; Events, Items, Doors
@@ -813,6 +815,7 @@ preset_kpdr25_wrecked_ship_phantoon:
     dl $7E09C8 : db $02 : dw $0019 ; Max missiles
     dl $7E09CA : db $02 : dw $0001 ; Supers
     dl $7E09CE : db $02 : dw $0002 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0089 ; Samus position/state
     dl $7E0A1E : db $02 : dw $1508 ; More position/state
     dl $7E0AF6 : db $02 : dw $04DB ; Samus X
@@ -948,6 +951,7 @@ preset_kpdr25_maridia_the_tube:
     dl $7E0915 : db $02 : dw $0100 ; Screen Y position in pixels
     dl $7E09C2 : db $02 : dw $00F3 ; Health
     dl $7E09CA : db $02 : dw $0009 ; Supers
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0009 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0108 ; More position/state
     dl $7E0AF6 : db $02 : dw $01B9 ; Samus X
@@ -972,6 +976,7 @@ preset_kpdr25_maridia_botwoon:
     dl $7E09C2 : db $02 : dw $00B8 ; Health
     dl $7E09CA : db $02 : dw $0008 ; Supers
     dl $7E09CE : db $02 : dw $0002 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $03BC ; Samus X
     dl $7E0AFA : db $02 : dw $008B ; Samus Y
     dl $7ED820 : db $02 : dw $0801 ; Events, Items, Doors
@@ -1148,6 +1153,7 @@ preset_kpdr25_lower_norfair_ln_elevator:
     dl $7E09C2 : db $02 : dw $01F0 ; Health
     dl $7E09C6 : db $02 : dw $0008 ; Missiles
     dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0007 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $007B ; Samus X
@@ -1183,6 +1189,7 @@ preset_kpdr25_lower_norfair_kihunter_stairs:
     dl $7E0915 : db $02 : dw $003F ; Screen Y position in pixels
     dl $7E09C2 : db $02 : dw $017B ; Health
     dl $7E09C6 : db $02 : dw $000A ; Missiles
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0011 ; Samus position/state
     dl $7E0AF6 : db $02 : dw $0309 ; Samus X
     dl $7E0AFA : db $02 : dw $00AF ; Samus Y

--- a/src/presets/pkrd_data.asm
+++ b/src/presets/pkrd_data.asm
@@ -2557,7 +2557,7 @@ preset_pkrd_tourian_escape_room_3:
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0A76 : db $02 : dw $8000 ; Hyper beam
-    dl $7E0AF6 : db $02 : dw $00DC ; Samus X
+    dl $7E0AF6 : db $02 : dw $00DF ; Samus X
     dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dl $7ED820 : db $02 : dw $4FC5 ; Events, Items, Doors
     dl $7ED82C : db $02 : dw $0203 ; Events, Items, Doors

--- a/src/presets/pkrd_data.asm
+++ b/src/presets/pkrd_data.asm
@@ -29,6 +29,7 @@ preset_pkrd_crateria_ship:
     dl $7E09CC : db $02 : dw $0000 ; Max supers
     dl $7E09CE : db $02 : dw $0000 ; Pbs
     dl $7E09D0 : db $02 : dw $0000 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E09D4 : db $02 : dw $0000 ; Max reserves
     dl $7E09D6 : db $02 : dw $0000 ; Reserves
     dl $7E0A1C : db $02 : dw $0000 ; Samus position/state
@@ -658,6 +659,7 @@ preset_pkrd_brinstar_caterpillars_up:
     dl $7E09C2 : db $02 : dw $0075 ; Health
     dl $7E09CE : db $02 : dw $0005 ; Pbs
     dl $7E09D0 : db $02 : dw $0005 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $02AF ; Samus X
@@ -703,6 +705,7 @@ preset_pkrd_brinstar_continuous_wall_jump:
     dl $7E0911 : db $02 : dw $0200 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $3000 ; Screen subpixel Y position
     dl $7E09CE : db $02 : dw $0001 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0089 ; Samus position/state
     dl $7E0A1E : db $02 : dw $1508 ; More position/state
     dl $7E0AF6 : db $02 : dw $02DB ; Samus X
@@ -1092,6 +1095,7 @@ preset_pkrd_red_brinstar_revisit_breaking_tube:
     dl $7E0913 : db $02 : dw $4400 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0100 ; Screen Y position in pixels
     dl $7E09CA : db $02 : dw $0008 ; Supers
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $01B6 ; Samus X
@@ -1112,6 +1116,7 @@ preset_pkrd_kraid_entering_kraids_lair:
     dl $7E0911 : db $02 : dw $0000 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $2001 ; Screen subpixel Y position
     dl $7E09CE : db $02 : dw $0002 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $002E ; Samus X
     dl $7ED820 : db $02 : dw $0801 ; Events, Items, Doors
     dw #$FFFF
@@ -1636,6 +1641,7 @@ preset_pkrd_lower_norfair_ln_main_hall:
     dl $7E0911 : db $02 : dw $0400 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
     dl $7E09C2 : db $02 : dw $0120 ; Health
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $009B ; Samus position/state
     dl $7E0A1E : db $02 : dw $0000 ; More position/state
     dl $7E0AF6 : db $02 : dw $0480 ; Samus X
@@ -1681,6 +1687,7 @@ preset_pkrd_lower_norfair_amphitheatre:
     dl $7E0913 : db $02 : dw $B800 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $011F ; Screen Y position in pixels
     dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0009 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0108 ; More position/state
     dl $7E0AF6 : db $02 : dw $00B8 ; Samus X

--- a/src/presets/prkd_data.asm
+++ b/src/presets/prkd_data.asm
@@ -2562,7 +2562,7 @@ preset_prkd_tourian_escape_room_3:
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0A76 : db $02 : dw $8000 ; Hyper beam
-    dl $7E0AF6 : db $02 : dw $00DC ; Samus X
+    dl $7E0AF6 : db $02 : dw $00DF ; Samus X
     dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dl $7ED820 : db $02 : dw $4FC5 ; Events, Items, Doors
     dl $7ED82C : db $02 : dw $0203 ; Events, Items, Doors

--- a/src/presets/prkd_data.asm
+++ b/src/presets/prkd_data.asm
@@ -29,6 +29,7 @@ preset_prkd_crateria_ship:
     dl $7E09CC : db $02 : dw $0000 ; Max supers
     dl $7E09CE : db $02 : dw $0000 ; Pbs
     dl $7E09D0 : db $02 : dw $0000 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E09D4 : db $02 : dw $0000 ; Max reserves
     dl $7E09D6 : db $02 : dw $0000 ; Reserves
     dl $7E0A1C : db $02 : dw $0000 ; Samus position/state
@@ -662,6 +663,7 @@ preset_prkd_brinstar_caterpillars_up:
     dl $7E09C2 : db $02 : dw $0075 ; Health
     dl $7E09CE : db $02 : dw $0005 ; Pbs
     dl $7E09D0 : db $02 : dw $0005 ; Max pbs
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $02AF ; Samus X
@@ -685,6 +687,7 @@ preset_prkd_brinstar_crateria_kihunters:
     dl $7E0913 : db $02 : dw $6400 ; Screen subpixel Y position
     dl $7E09CA : db $02 : dw $0005 ; Supers
     dl $7E09CE : db $02 : dw $0003 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0004 ; More position/state
     dl $7E0AF6 : db $02 : dw $007E ; Samus X
@@ -1096,6 +1099,7 @@ preset_prkd_red_brinstar_revisit_breaking_tube:
     dl $7E0913 : db $02 : dw $4400 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0100 ; Screen Y position in pixels
     dl $7E09CA : db $02 : dw $0008 ; Supers
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $01B6 ; Samus X
@@ -1114,6 +1118,7 @@ preset_prkd_upper_norfair_business_center:
     dl $7E0913 : db $02 : dw $2001 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
     dl $7E09CE : db $02 : dw $0002 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $0080 ; Samus X
     dl $7E0AFA : db $02 : dw $008B ; Samus Y
     dl $7ED820 : db $02 : dw $0801 ; Events, Items, Doors
@@ -1489,6 +1494,7 @@ preset_prkd_lower_norfair_ln_main_hall:
     dl $7E0913 : db $02 : dw $0000 ; Screen subpixel Y position
     dl $7E09A6 : db $02 : dw $1001 ; Beams
     dl $7E09C2 : db $02 : dw $00B4 ; Health
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $009B ; Samus position/state
     dl $7E0A1E : db $02 : dw $0000 ; More position/state
     dl $7E0AF6 : db $02 : dw $0480 ; Samus X
@@ -1534,6 +1540,7 @@ preset_prkd_lower_norfair_amphitheatre:
     dl $7E0913 : db $02 : dw $A400 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $011C ; Screen Y position in pixels
     dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0AF6 : db $02 : dw $00B1 ; Samus X
     dl $7E0AFA : db $02 : dw $018B ; Samus Y
     dw #$FFFF
@@ -2026,6 +2033,7 @@ preset_prkd_maridia_aqueduct:
     dl $7E0911 : db $02 : dw $0006 ; Screen X position in pixels
     dl $7E0913 : db $02 : dw $F001 ; Screen subpixel Y position
     dl $7E0915 : db $02 : dw $0300 ; Screen Y position in pixels
+    dl $7E09D2 : db $02 : dw $0003 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0001 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0008 ; More position/state
     dl $7E0AF6 : db $02 : dw $0078 ; Samus X
@@ -2048,6 +2056,7 @@ preset_prkd_maridia_botwoon_hallway:
     dl $7E0915 : db $02 : dw $0000 ; Screen Y position in pixels
     dl $7E09CA : db $02 : dw $0008 ; Supers
     dl $7E09CE : db $02 : dw $0004 ; Pbs
+    dl $7E09D2 : db $02 : dw $0000 ; Currently selected item
     dl $7E0A1C : db $02 : dw $0002 ; Samus position/state
     dl $7E0A1E : db $02 : dw $0004 ; More position/state
     dl $7E0AF6 : db $02 : dw $009F ; Samus X

--- a/src/spriteprio.asm
+++ b/src/spriteprio.asm
@@ -73,7 +73,7 @@ oam_add_samus_sprite_with_prio:
     ADC $12           ;} OAM entry Y position = [[Y] + 2] + [$12] (Y position)
     STA $0371,x       ;/
     LDA $0003,y       ;\
-    ORA !ram_sprite_prio_flag
+    ORA !sram_sprite_prio_flag
     STA $0372,x       ;} OAM entry tile number and attributes = [[Y] + 3]
     TYA               ;\
     CLC               ;|

--- a/website/ClientApp/src/components/Changelog.js
+++ b/website/ClientApp/src/components/Changelog.js
@@ -31,6 +31,10 @@ export class Changelog extends Component {
                                                 <li>Replaced vertical speed subpixels with jump feedback. (2.2.1)</li>
                                                 <li>When fanfare is off, music is not interrupted. (2.2.1)</li>
                                                 <li>Added average climb speed to the Wall Jump infohud mode. (2.2.2)</li>
+                                                <li>Automatically select Power Bombs when loading certain presets. (2.2.3)</li>
+                                                <li>Added RAM Watch HUD mode with a new InfoHUD menu. (2.2.3)</li>
+                                                <li>Update HUD timers when boss drops spawn. (2.2.3)</li>
+                                                <li>Reset segment timer at game start for practice run timing. (2.2.3)</li>
                                             </ul>
                                         </CardBody>
                                     </Card>

--- a/website/ClientApp/src/components/Changelog.js
+++ b/website/ClientApp/src/components/Changelog.js
@@ -35,6 +35,7 @@ export class Changelog extends Component {
                                                 <li>Added RAM Watch HUD mode with a new InfoHUD menu. (2.2.3)</li>
                                                 <li>Update HUD timers when boss drops spawn. (2.2.3)</li>
                                                 <li>Reset segment timer at game start for practice run timing. (2.2.3)</li>
+                                                <li>Added initial jump speed to vertical speed display. (2.2.3)</li>
                                             </ul>
                                         </CardBody>
                                     </Card>

--- a/website/ClientApp/src/components/Help.js
+++ b/website/ClientApp/src/components/Help.js
@@ -27,7 +27,7 @@ export class Help extends Component {
                                         <li>Item collection percentage</li>
                                         <li>Number of E-tanks</li>
                                         <li>Current total energy</li>
-                                        <li>Segment timer in minutes.seconds.frames. Resets when loading a preset or by controller shortcut</li>
+                                        <li>Segment timer in minutes.seconds.frames. Resets when starting a new game, loading a preset, or by controller shortcut.</li>
                                         <li>Timer in seconds.frames, resets when entering a new room and updates on item acquisition and room transitions. Can be set to realtime or gametime</li>
                                         <li>Lag frames, updates same as above</li>
                                         <li>Frames spent by last door transition</li>
@@ -237,6 +237,17 @@ export class Help extends Component {
                             <Row>
                                 <Col md="3" className="offset-md-1">Artificial Lag</Col>
                                 <Col>Select a value to adjust how much lag occurs during normal gameplay. This is to compensate for the lack of a minimap on the HUD which would normally consume CPU cycles.</Col>
+                            </Row>
+                            <Row>
+                                <Col md="3" className="offset-md-1">Customize RAM Watch</Col>
+                                <Col>Setup addresses to be monitored by the RAM Watch HUD mode. Address 1 will appear in the bottom-left corner of the HUD, while Address 2 appears just to the right of Address 1.
+                                Memory at these locations can be edited by configuring a Value and selecting 'Write to Address'. Toggle 'Lock Value' to automatically write the value once every frame. RAM Watch must
+                                must be the selected HUD mode to continue writing to the address.</Col>
+                            </Row>
+                            <Row>
+                                <Col md="3" className="offset-md-1"></Col>
+                                <Col>Only one byte of hex can be configured at a time in the menu. 'Hi' refers to the first byte, while 'Lo' refers to the second. Set the Hi Address to 0D and the Lo Address to EC
+                                to monitor the memory address $0DEC, which stores the counter for Samus direction changes while held by Draygon (among other uses).</Col>
                             </Row>
                             <br />
                             <Row>

--- a/website/ClientApp/src/components/Home.js
+++ b/website/ClientApp/src/components/Home.js
@@ -10,7 +10,7 @@ export class Home extends Component {
       <Row className="justify-content-center">
         <Col md="8">
           <div>
-              <Patcher version="2.2.2"/>
+              <Patcher version="2.2.3"/>
           </div>
         </Col>
       </Row>

--- a/website/ClientApp/src/components/InfohudMode.js
+++ b/website/ClientApp/src/components/InfohudMode.js
@@ -262,6 +262,12 @@ export class InfohudMode extends Component {
                                 <Col md="3">Shot Timer</Col>
                                 <Col>Displays the number of frames between pressing the shoot button.</Col>
                             </Row>
+                            <br />
+                            <Row>
+                                <Col md="3">RAM Watch</Col>
+                                <Col>Displays the value of two configurable memory addresses in $7E. Values can also be "locked" or rewritten each frame
+                                while the RAM Watch HUD mode is enabled. These addresses and values can be configured in the 'Customize RAM Watch' submenu.</Col>
+                            </Row>
                       </CardBody>
                     </Card>
                     <br />

--- a/website/ClientApp/src/components/InfohudMode.js
+++ b/website/ClientApp/src/components/InfohudMode.js
@@ -197,7 +197,7 @@ export class InfohudMode extends Component {
                             <br />
                             <Row>
                                 <Col md="3">Vert Speed</Col>
-                                <Col>Displays the vertical speed in pixels. Also Samus HP will be overwritten with space jump feedback:</Col>
+                                <Col>Displays the vertical speed in pixels. Initial jump speed will displayed as a three digit hex value, overwriting the item collection percentage. Samus HP will be overwritten with space jump feedback:</Col>
                             </Row>
                             <Row>
                                 <Col md="3"></Col>


### PR DESCRIPTION
**Automatically select Power Bombs when loading certain presets.** teledump.lua will now record the currently selected item in preset data. We should be careful not to equip missiles or supers when making new presets. Most existing categories have been manually updated to equip power bombs at certain presets where they will ALWAYS be used in the next room.

**Added RAM Watch HUD mode with a new InfoHUD menu.** RAM Watch can be used to monitor any address in $7E space. Addresses are configured in a separate submenu within the InfoHUD menu. Optionally, values can be written to the configured addresses or "locked" to be rewritten every frame (as long as RAM Watch is selected as the current HUD mode). This required adding an additional number field menu item that supports hexidecimal.

**Update HUD timers when boss drops spawn.** Requested feature. Runs ih_update_hud_early during boss drop spawn routines.

**Reset segment timer at game start for practice run timing.** Requested feature. Previously, the segment timer began running shortly after power on. It will now reset on START GAME and initialize to 1:50 to account for the frames it will miss as Ceres is loading. There was an existing hijack that reset all timers after completing Ceres. This has been changed so that it adds 1:13 to the segment timer to account for frames missed while loading Zebes and cutscenes. All other timers are still reset at this time. With these changes, the segment timer can be used to approximate RTA timing in a practice run or theory TAS. Note that starting from a fresh file will add 20 frames to the Ceres loading sequence. This is not accounted for.

I've also moved the sprite priority flag into SRAM so that it won't be reset when loading a preset or savestate.