### PR TITLE
Chozo grab segment and door stuck fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,4 @@ The build script will create two IPS patch files for the practice hack. The patc
 
 ## Known Issues:
 
-* Loading a preset while in a loading transition can sometimes cause Samus to freeze when exiting the next door.
 * PAL region roms are no longer supported in the main branch. See https://github.com/InsaneFirebat/sm_practice_hack/tree/PAL-v1.43 for the latest working PAL revision.

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -108,6 +108,9 @@ org $A0BB13      ; update timers when Spore Spawn drops spawn
 org $A0BB46      ; update timers when Draygon drops spawn
     JSL ih_drops_segment
 
+org $AAE582      ; update timers when statue grabs Samus
+    JSL ih_chozo_segment
+
 org $9AB200         ; graphics for HUD
 incbin ../resources/hudgfx.bin
 
@@ -330,6 +333,13 @@ ih_drops_segment:
     ; runs when boss drops spawn
     JSL ih_update_hud_early
     JSL $808111 ; overwritten code
+    RTL
+}
+
+ih_chozo_segment:
+{
+    JSL $8090CB ; overwritten code
+    JSL ih_update_hud_early
     RTL
 }
 

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -146,7 +146,7 @@ MainMenu:
     dw #mm_goto_rngmenu
     dw #mm_goto_ctrlsmenu
     dw #$0000
-    %cm_header("SM PRACTICE HACK 2.2.3")
+    %cm_header("SM PRACTICE HACK 2.2.4")
 
 mm_goto_equipment:
     %cm_submenu("Equipment", #EquipmentMenu)

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -79,6 +79,7 @@ preset_load:
     JSL !MUSIC_ROUTINE
 
     JSL reset_all_counters
+    STZ $0795 ; clear door transition flag
 
     ; Clear enemies (8000 = solid to Samus, 0400 = Ignore Samus projectiles)
     LDA #$0000
@@ -91,7 +92,6 @@ preset_load:
     PLP
     RTL
 }
-
 
 reset_all_counters:
 {

--- a/website/ClientApp/src/components/Changelog.js
+++ b/website/ClientApp/src/components/Changelog.js
@@ -36,6 +36,8 @@ export class Changelog extends Component {
                                                 <li>Update HUD timers when boss drops spawn. (2.2.3)</li>
                                                 <li>Reset segment timer at game start for practice run timing. (2.2.3)</li>
                                                 <li>Added initial jump speed to vertical speed display. (2.2.3)</li>
+                                                <li>Update room timers when grabbed by statues. (2.2.4)</li>
+                                                <li>Fixed door stuck bug after loading presets from a door transition. (2.2.4)</li>
                                             </ul>
                                         </CardBody>
                                     </Card>

--- a/website/ClientApp/src/components/Home.js
+++ b/website/ClientApp/src/components/Home.js
@@ -10,7 +10,7 @@ export class Home extends Component {
       <Row className="justify-content-center">
         <Col md="8">
           <div>
-              <Patcher version="2.2.3"/>
+              <Patcher version="2.2.4"/>
           </div>
         </Col>
       </Row>


### PR DESCRIPTION
HUD timers will now update when bowling and acid chozo statues grab onto Samus.

The door transition flag is now cleared when loading a preset. This was the cause of the "door stuck" bug after loading a preset from a door transition. Only rooms with elevators were affected. The "handle door transitions" routine at $82E17D checks if the elevator is active ($0E16) to know if it's handling a door. The elevator is active when Samus is standing still on it, but the main elevator routine ($A3952A) branches out immediately if the door transition flag is set. This makes the elevator unresponsive to Samus pressing down and unable to clear its own flag when Samus steps off. 

You can write a 1 to $0795 after loading a Brinstar Elevator preset to artificially reproduce the issue. When you go through a door, the game will assume Samus needs to be locked for the elevator ride. 