### PR TITLE
Room/Door Timers with Minimap + Magnet Stair Fix

### DIFF
--- a/src/defines.asm
+++ b/src/defines.asm
@@ -36,6 +36,7 @@
 !ram_vcounter_data = $7FFB8C
 !ram_minimap = $7FFB98
 !ram_shot_timer = $7FFB9E
+!ram_magnetstairs = $7FFBA6
 
 !ram_kraid_rng = $7FFB78
 !ram_phantoon_rng_3 = $7FFB7A

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -162,7 +162,7 @@ MainMenu:
     dw #mm_goto_rngmenu
     dw #mm_goto_ctrlsmenu
     dw #$0000
-    %cm_header("SM PRACTICE HACK 2.2.4")
+    %cm_header("SM PRACTICE HACK 2.2.5")
 
 mm_goto_equipment:
     %cm_submenu("Equipment", #EquipmentMenu)
@@ -806,6 +806,7 @@ MiscMenu:
     dw #misc_music_toggle
     dw #misc_transparent
     dw #misc_invincibility
+    dw #misc_magnetstairs
     dw #$0000
     %cm_header("MISC")
 
@@ -859,6 +860,26 @@ misc_transparent:
 
 misc_invincibility:
     %cm_toggle_bit("Invincibility", $7E0DE0, #$0007, #0)
+
+misc_magnetstairs:
+    %cm_toggle("Magnet Stairs Fix", !ram_magnetstairs, #$0001, #.routine)
+    .routine
+        LDA $079B : CMP #$DFD7 : BNE .done
+        LDA !ram_magnetstairs : BEQ .broken
+        PHP : %a8()
+        LDA #$10 : STA $7F01F9 : STA $7F02EB
+        LDA #$53 : STA $7F64FD : STA $7F6576
+        PLP
+        RTS
+
+      .broken
+        PHP : %a8()
+        LDA #$80 : STA $7F01F9 : STA $7F02EB
+        LDA #$00 : STA $7F64FD : STA $7F6576
+        PLP
+
+      .done
+        RTS
 
 
 ; -----------

--- a/src/misc.asm
+++ b/src/misc.asm
@@ -135,5 +135,21 @@ stop_all_sounds:
     RTL
 }
 
+org $83AB92 ; Magnet Stairs (right) door asm pointer
+    dw $EA00
+
+org $83AB6E ; Magnet Stairs (left) door asm pointer
+    dw $EA00
+
+org $8FEA00 ; free space for Magnet Stairs door asm
+    LDA !ram_magnetstairs : BEQ .done
+    PHP : %a8()
+    LDA #$10 : STA $7F01F9 : STA $7F02EB
+    LDA #$53 : STA $7F64FD : STA $7F6576
+    PLP
+
+  .done
+    RTS
+
 print pc, " misc end"
 

--- a/website/ClientApp/src/components/Changelog.js
+++ b/website/ClientApp/src/components/Changelog.js
@@ -41,6 +41,7 @@ export class Changelog extends Component {
                                                 <li>Added minimap option, debug CPU brightness option, Kraid claw RNG. (2.2.4)</li>
                                                 <li>Allow GT Max% equipment levels. (2.2.4)</li>
                                                 <li>CPU% calcalation now includes the artifical lag. (2.2.4)</li>
+                                                <li>Restored room timers while minimap is enabled. (2.2.5)</li>
                                             </ul>
                                         </CardBody>
                                     </Card>

--- a/website/ClientApp/src/components/Changelog.js
+++ b/website/ClientApp/src/components/Changelog.js
@@ -42,6 +42,7 @@ export class Changelog extends Component {
                                                 <li>Allow GT Max% equipment levels. (2.2.4)</li>
                                                 <li>CPU% calcalation now includes the artifical lag. (2.2.4)</li>
                                                 <li>Restored room timers while minimap is enabled. (2.2.5)</li>
+                                                <li>Added a toggle to fix Magnet Stairs. (2.2.5)</li>
                                             </ul>
                                         </CardBody>
                                     </Card>

--- a/website/ClientApp/src/components/Home.js
+++ b/website/ClientApp/src/components/Home.js
@@ -10,7 +10,7 @@ export class Home extends Component {
       <Row className="justify-content-center">
         <Col md="8">
           <div>
-              <Patcher version="2.2.4"/>
+              <Patcher version="2.2.5"/>
           </div>
         </Col>
       </Row>


### PR DESCRIPTION
This splits `ih_update_hud_code` based on the minimap toggle. When enabled, the map tile counter will be drawn at the top-left where item% would normally be. The door transition timer is drawn directly below it. The room timer is drawn next to the minimap.

I also added a toggle for fixing the "magnet stairs" bug. If you're not familiar, the top of the stairs should have a square slope tile directly after it, but these are missing in the Magnet Stairs room. When your X position lands on the right value passing over them, you will come to a full stop for one frame.

This fix uses door asm (runs about halfway through transition) to overwrite the two tiles. I hijacked both doors just to prevent the inevitable "this doesn't work" when someone tries to test it before the escape. The menu toggle will also fix the stairs if you're currently in the room.

Edit:  Fixed a typo and tested the squash thing to merge the relevant commits. Worked well but doesn't seem to show what I did.