### PR TITLE
Reorganize Defines

### DIFF
--- a/src/defines.asm
+++ b/src/defines.asm
@@ -63,26 +63,26 @@
 !ram_roomstrat_counter = $7FFB82
 !ram_roomstrat_state = $7FFB84
 !ram_enemy_hp = $7FFB86
-!ram_mb_hp = $7FFB86
-!ram_shot_timer = $7FFB88
-!ram_shine_counter = $7FFB8A
-!ram_dash_counter = $7FFB8C
-!ram_shine_dash_held_late = $7FFB8E
-!ram_shinetune_early_1 = $7FFB90
-!ram_shinetune_late_1 = $7FFB92
-!ram_shinetune_early_2 = $7FFB94
-!ram_shinetune_late_2 = $7FFB96
-!ram_shinetune_early_3 = $7FFB98
-!ram_shinetune_late_3 = $7FFB9A
-!ram_shinetune_early_4 = $7FFB9C
-!ram_shinetune_late_4 = $7FFB9E
-!ram_xpos = $7FFBA0
-!ram_ypos = $7FFBA2
-!ram_subpixel_pos = $7FFBA4
-!ram_horizontal_speed = $7FFBA6
-!ram_vertical_speed = $7FFBA8
-!ram_quickdrop_counter = $7FFBAA
-!ram_walljump_counter = $7FFB8AC
+!ram_mb_hp = $7FFB88
+!ram_shot_timer = $7FFB8A
+!ram_shine_counter = $7FFB8C
+!ram_dash_counter = $7FFB8E
+!ram_shine_dash_held_late = $7FFB90
+!ram_shinetune_early_1 = $7FFB92
+!ram_shinetune_late_1 = $7FFB94
+!ram_shinetune_early_2 = $7FFB96
+!ram_shinetune_late_2 = $7FFB98
+!ram_shinetune_early_3 = $7FFB9A
+!ram_shinetune_late_3 = $7FFB9C
+!ram_shinetune_early_4 = $7FFB9E
+!ram_shinetune_late_4 = $7FFBA0
+!ram_xpos = $7FFBA2
+!ram_ypos = $7FFBA4
+!ram_subpixel_pos = $7FFBA6
+!ram_horizontal_speed = $7FFBA8
+!ram_vertical_speed = $7FFBAA
+!ram_quickdrop_counter = $7FFBAC
+!ram_walljump_counter = $7FFBAE
 
 ; FREE SPACE ^
 

--- a/src/defines.asm
+++ b/src/defines.asm
@@ -1,156 +1,139 @@
-!ram_gametime_room = $7FFB00
-!ram_last_gametime_room = $7FFB02
-!ram_realtime_room = $7FFB44
-!ram_last_realtime_room = $7FFB46
-!ram_last_room_lag = $7FFB48
+!ram_load_preset = $7FFB00
+
+!ram_gametime_room = $7FFB02
+!ram_last_gametime_room = $7FFB04
+!ram_realtime_room = $7FFB06
+!ram_last_realtime_room = $7FFB08
+!ram_last_room_lag = $7FFB0A
+!ram_last_door_lag_frames = $7FFB0C
 !ram_transition_counter = $7FFB0E
-!ram_last_door_lag_frames = $7FFB10
+!ram_transition_flag = $7FFB10
+!ram_transition_flag_2 = $7FFB12
 
-!ram_armed_shine_duration = $7FFB14
-!ram_etanks = $7FFB12 ; ??
-!ram_max_etanks = $7FFB24 ; ??
-!ram_last_hp = $7FFB9A
+!ram_seg_rt_frames = $7FFB14
+!ram_seg_rt_seconds = $7FFB16
+!ram_seg_rt_minutes = $7FFB18
 
-!ram_slowdown_mode = $7EFFFC
-!ram_slowdown_frames = $7FFB52
-!ram_shine_dash_held_late = $7FFB1A
-!ram_shine_counter = $7FFB30
-!ram_cooldown_counter = $7FFB32
-!ram_xpos = $7FFB34
-!ram_ypos = $7FFB36
-!ram_dash_counter = $7FFB38
-!ram_iframe_counter = $7FFB3A
-!ram_subpixel_pos = $7FFB3C
-!ram_mb_hp = $7FFB3E
-!ram_enemy_hp = $7FFB40
-!ram_horizontal_speed = $7FFB58
-!ram_vertical_speed = $7FFB5A
-!ram_magic_pants_enabled = $7FFB64
-!ram_magic_pants_state = $7FFB66
-!ram_magic_pants_pal1 = $7FFB70
-!ram_magic_pants_pal2 = $7FFB72
-!ram_magic_pants_pal3 = $7FFB74
-!ram_charge_counter = $7FFB1C
-!ram_xfac_counter = $7FFB1E
-!ram_map_counter = $7FFB8A
-!ram_vcounter_data = $7FFB8C
-!ram_minimap = $7FFB98
-!ram_shot_timer = $7FFB9E
+!ram_ih_controller = $7FFB1A
+!ram_slowdown_controller_1 = $7FFB1C
+!ram_slowdown_controller_2 = $7FFB1E
+!ram_slowdown_mode = $7FFB20
+!ram_slowdown_frames = $7FFB22
 
-!ram_kraid_rng = $7FFB78
-!ram_phantoon_rng_3 = $7FFB7A
-!ram_crocomire_rng = $7FFB7C
-!ram_draygon_rng_left = $7FFB7E
-!ram_draygon_rng_right = $7FFB80
-!ram_phantoon_rng_1 = $7FFB82
-!ram_phantoon_rng_2 = $7FFB84
-!ram_botwoon_rng = $7FFB86
-!ram_room_has_set_rng = $7FFB88
+!ram_tmp_1 = $7FFB24
+!ram_tmp_2 = $7FFB26
+!ram_tmp_3 = $7FFB28
+!ram_tmp_4 = $7FFB2A
 
-!ram_tmp_1 = $7FFB4C
-!ram_tmp_2 = $7FFB4E
-!ram_tmp_3 = $7FFB08
-!ram_tmp_4 = $7FFB0A
-!ram_transition_flag = $7FFB16
-!ram_transition_flag_2 = $7FFB2C
-!ram_pct_1 = $7FFB20
-!ram_pct_2 = $7FFB26
-!ram_ih_controller = $7FFB42
-!ram_slowdown_controller_1 = $7FFB54
-!ram_slowdown_controller_2 = $7FFB56
+!ram_last_hp = $7FFB2C
+!ram_etanks = $7FFB2E
+!ram_pct_1 = $7FFB30
+!ram_pct_2 = $7FFB32
+!ram_armed_shine_duration = $7FFB34
+!ram_minimap = $7FFB36
+!ram_map_counter = $7FFB38
+!ram_vcounter_data = $7FFB3A
 
-!ram_seg_rt_frames = $7FFBA0
-!ram_seg_rt_seconds = $7FFBA2
-!ram_seg_rt_minutes = $7FFBA4
+; FREE SPACE ^
 
-!ram_cm_ctrl_mode = $7FFBC0
-!ram_cm_ctrl_timer = $7FFBC2
-!ram_cm_ctrl_last_input = $7FFBC4
+!ram_magic_pants_enabled = $7FFB50
+!ram_magic_pants_state = $7FFB52
+!ram_magic_pants_pal1 = $7FFB54
+!ram_magic_pants_pal2 = $7FFB56
+!ram_magic_pants_pal3 = $7FFB58
 
-!ram_roomstrat_counter = $7FFBC6
-!ram_roomstrat_state = $7FFBC8
-!ram_walljump_counter = $7FFBCA
-!ram_quickdrop_counter = $7FFBCC
+!ram_room_has_set_rng = $7FFB5A
+!ram_kraid_rng = $7FFB5C
+!ram_crocomire_rng = $7FFB5E
+!ram_phantoon_rng_1 = $7FFB60
+!ram_phantoon_rng_2 = $7FFB62
+!ram_phantoon_rng_3 = $7FFB64
+!ram_botwoon_rng = $7FFB66
+!ram_draygon_rng_left = $7FFB68
+!ram_draygon_rng_right = $7FFB6A
 
-!ram_shinetune_early_1 = $7FFBD0
-!ram_shinetune_late_1 = $7FFBD2
-!ram_shinetune_early_2 = $7FFBD4
-!ram_shinetune_late_2 = $7FFBD6
-!ram_shinetune_early_3 = $7FFBD8
-!ram_shinetune_late_3 = $7FFBDA
-!ram_shinetune_early_4 = $7FFBDC
-!ram_shinetune_late_4 = $7FFBDE
+; FREE SPACE ^
 
-!ram_watch_left = $7FFC30
-!ram_watch_left_hud = $7FFC32
-!ram_watch_left_hi = $7FFC34
-!ram_watch_left_lo = $7FFC36
-!ram_watch_right = $7FFC38
-!ram_watch_right_hud = $7FFC3A
-!ram_watch_right_hi = $7FFC3C
-!ram_watch_right_lo = $7FFC3E
-!ram_watch_edit_left = $7FFC40
-!ram_watch_edit_left_hi = $7FFC42
-!ram_watch_edit_left_lo = $7FFC44
-!ram_watch_edit_right = $7FFC46
-!ram_watch_edit_right_hi = $7FFC48
-!ram_watch_edit_right_lo = $7FFC4A
-!ram_watch_edit_lock_left = $7FFC4C
-!ram_watch_edit_lock_right = $7FFC4E
 
-; -----
-; SRAM
-; -----
+; --------
+; Infohud
+; --------
 
-!sram_initialized = $702000
+!ram_HUD_check = $7FFB80
+!ram_roomstrat_counter = $7FFB82
+!ram_roomstrat_state = $7FFB84
+!ram_enemy_hp = $7FFB86
+!ram_mb_hp = $7FFB86
+!ram_shot_timer = $7FFB88
+!ram_shine_counter = $7FFB8A
+!ram_dash_counter = $7FFB8C
+!ram_shine_dash_held_late = $7FFB8E
+!ram_shinetune_early_1 = $7FFB90
+!ram_shinetune_late_1 = $7FFB92
+!ram_shinetune_early_2 = $7FFB94
+!ram_shinetune_late_2 = $7FFB96
+!ram_shinetune_early_3 = $7FFB98
+!ram_shinetune_late_3 = $7FFB9A
+!ram_shinetune_early_4 = $7FFB9C
+!ram_shinetune_late_4 = $7FFB9E
+!ram_xpos = $7FFBA0
+!ram_ypos = $7FFBA2
+!ram_subpixel_pos = $7FFBA4
+!ram_horizontal_speed = $7FFBA6
+!ram_vertical_speed = $7FFBA8
+!ram_quickdrop_counter = $7FFBAA
+!ram_walljump_counter = $7FFB8AC
 
-!sram_ctrl_menu = $702002
-!sram_ctrl_kill_enemies = $702004
-!sram_ctrl_full_equipment = $702006
-!sram_ctrl_reset_segment_timer = $702008
-!sram_ctrl_load_state = $70200A
-!sram_ctrl_save_state = $70200C
-!sram_ctrl_load_last_preset = $70200E
-!sram_ctrl_random_preset = $702024
+; FREE SPACE ^
 
-!sram_artificial_lag = $702010
-!sram_rerandomize = $702012
-!sram_fanfare_toggle = $702014
-!sram_frame_counter_mode = $702016
-!sram_display_mode = $702018
-!sram_music_toggle = $70201A
-!sram_last_preset = $70201C
-!sram_save_has_set_rng = $70201E
-!sram_preset_category = $702020
-!sram_room_strat = $702022
-!sram_sprite_prio_flag = $702026
+!ram_watch_left = $7FFBE0
+!ram_watch_left_hud = $7FFBE2
+!ram_watch_left_hi = $7FFBE4
+!ram_watch_left_lo = $7FFBE6
+!ram_watch_right = $7FFBE8
+!ram_watch_right_hud = $7FFBEA
+!ram_watch_right_hi = $7FFBEC
+!ram_watch_right_lo = $7FFBEE
+!ram_watch_edit_left = $7FFBF0
+!ram_watch_edit_left_hi = $7FFBF2
+!ram_watch_edit_left_lo = $7FFBF4
+!ram_watch_edit_right = $7FFBF6
+!ram_watch_edit_right_hi = $7FFBF8
+!ram_watch_edit_right_lo = $7FFBFA
+!ram_watch_edit_lock_left = $7FFBFC
+!ram_watch_edit_lock_right = $7FFBFE
 
 
 ; -------------
 ; Menu
 ; -------------
 
-!ram_cm_menu_stack = $7FFFD0 ; 0x10
-!ram_cm_cursor_stack = $7FFFE0 ; 0x10
 !ram_cm_stack_index = $5D5
-!ram_cm_cursor_max = $7FFFF2
-!ram_cm_input_timer = $7FFFF4
-!ram_cm_controller = $7FFFF6
-!ram_cm_menu_bank = $7FFFF8
+!ram_cm_menu_stack = $7FFF00 ; 0x10
+!ram_cm_cursor_stack = $7FFF10 ; 0x10
+!ram_cm_cursor_max = $7FFF20
+!ram_cm_input_timer = $7FFF22
+!ram_cm_controller = $7FFF24
+!ram_cm_menu_bank = $7FFF26
 
-!ram_cm_etanks = $7FFB90
-!ram_cm_reserve = $7FFB92
-!ram_cm_leave = $7FFB94
-!ram_cm_input_counter = $7FFB96
-!ram_cm_last_nmi_counter = $7FFB9C
+!ram_cm_etanks = $7FFF28
+!ram_cm_reserve = $7FFF2A
+!ram_cm_leave = $7FFF2C
+!ram_cm_input_counter = $7FFF2E
+!ram_cm_last_nmi_counter = $7FFF30
+
+!ram_cm_ctrl_mode = $7FFF32
+!ram_cm_ctrl_timer = $7FFF34
+!ram_cm_ctrl_last_input = $7FFF36
+
+; FREE SPACE ^
+
+!ram_cgram_cache = $7FFFD0 ; 0x14 bytes
 
 !ram_hex2dec_first_digit = $14
 !ram_hex2dec_second_digit = $16
 !ram_hex2dec_third_digit = $18
 !ram_hex2dec_rest = $1A
-
-!ram_ctrl1 = $8B
-!ram_ctrl1_filtered = $8F
 
 !ACTION_TOGGLE          = #$0000
 !ACTION_TOGGLE_BIT      = #$0002
@@ -165,9 +148,10 @@
 !SOUND_MENU_MOVE = $0039
 !SOUND_MENU_JSR = $0039
 
-; --------
-; Infohud
-; --------
+
+; ------------
+; Pointers
+; ------------
 
 !IH_CONTROLLER_PRI = $8B
 !IH_CONTROLLER_PRI_NEW = $8F
@@ -176,6 +160,23 @@
 !IH_CONTROLLER_SEC = $8D
 !IH_CONTROLLER_SEC_NEW = $91
 !IH_CONTROLLER_SEC_PREV = $99
+
+!IH_BLANK = #$0057
+!IH_PERCENT = #$0C0A
+!IH_DECIMAL = #$0CCB
+!IH_HYPHEN = #$0C55
+!IH_LETTER_A = #$0C64
+!IH_LETTER_B = #$0C65
+!IH_LETTER_C = #$0C58
+!IH_LETTER_D = #$0C59
+!IH_LETTER_E = #$0C5A
+!IH_LETTER_F = #$0C5B
+!IH_LETTER_H = #$0C6C
+!IH_LETTER_L = #$0C68
+!IH_LETTER_N = #$0C56
+!IH_LETTER_R = #$0C69
+!IH_LETTER_X = #$0C66
+!IH_LETTER_Y = #$0C67
 
 !IH_PAUSE = #$0100 ; right
 !IH_SLOWDOWN = #$0400 ; down
@@ -196,36 +197,46 @@
 !IH_INPUT_ANGLE_UP = $7E09BC
 !IH_INPUT_ANGLE_DOWN = $7E09BE
 
-!IH_BLANK = #$0057
-!IH_DECIMAL = #$0CCB
-!IH_HYPHEN = #$0C55
-!IH_LETTER_A = #$0C64
-!IH_LETTER_B = #$0C65
-!IH_LETTER_C = #$0C58
-!IH_LETTER_D = #$0C59
-!IH_LETTER_E = #$0C5A
-!IH_LETTER_F = #$0C5B
-!IH_LETTER_H = #$0C6C
-!IH_LETTER_L = #$0C68
-!IH_LETTER_N = #$0C56
-!IH_LETTER_R = #$0C69
-!IH_LETTER_X = #$0C66
-!IH_LETTER_Y = #$0C67
-!IH_PERCENT = #$0C0A
 
-; ------------
-; Presets
-; ------------
+; -----
+; SRAM
+; -----
 
-!ram_load_preset = $7FFC00
-!ram_cgram_cache = $7FFC02 ; 0x14 bytes
+!sram_initialized = $702000
+
+!sram_ctrl_menu = $702002
+!sram_ctrl_kill_enemies = $702004
+!sram_ctrl_full_equipment = $702006
+!sram_ctrl_reset_segment_timer = $702008
+!sram_ctrl_load_state = $70200A
+!sram_ctrl_save_state = $70200C
+!sram_ctrl_load_last_preset = $70200E
+!sram_ctrl_random_preset = $702010
+
+; FREE SPACE ^
+
+!sram_artificial_lag = $702020
+!sram_rerandomize = $702022
+!sram_fanfare_toggle = $702024
+!sram_frame_counter_mode = $702026
+!sram_display_mode = $702028
+!sram_music_toggle = $70202A
+!sram_last_preset = $70202C
+!sram_save_has_set_rng = $70202E
+!sram_preset_category = $702030
+!sram_room_strat = $702032
+!sram_sprite_prio_flag = $702034
+
+; FREE SPACE ^
+
 
 ; ----------
-; Save/load
+; Save/Load
 ; ----------
 
 ; Savestate code variables
 !SS_BANK = $8000
+
 !SS_INPUT_CUR = $8B
 !SS_INPUT_NEW = $8F
 !SS_INPUT_PREV = $97

--- a/src/gamemode.asm
+++ b/src/gamemode.asm
@@ -35,45 +35,43 @@ gamemode_start:
 
 gamemode_shortcuts:
 {
-    LDA !ram_ctrl1_filtered : BNE +
+    LDA !IH_CONTROLLER_PRI_NEW : BNE +
 
     ; No shortcuts configured, CLC so we won't skip normal gameplay
     CLC : RTS
 
-  + LDA !ram_ctrl1 : CMP !sram_ctrl_save_state : BNE +
-    AND !ram_ctrl1_filtered : BEQ +
     if !FEATURE_SD2SNES
+  + LDA !IH_CONTROLLER_PRI : CMP !sram_ctrl_save_state : BNE +
+    AND !IH_CONTROLLER_PRI_NEW : BEQ +
         JMP .save_state
-    endif
 
-  + LDA !ram_ctrl1 : CMP !sram_ctrl_load_state : BNE +
-    AND !ram_ctrl1_filtered : BEQ +
-    if !FEATURE_SD2SNES
+  + LDA !IH_CONTROLLER_PRI : CMP !sram_ctrl_load_state : BNE +
+    AND !IH_CONTROLLER_PRI_NEW : BEQ +
         JMP .load_state
     endif
 
-  + LDA !ram_ctrl1 : AND !sram_ctrl_kill_enemies : CMP !sram_ctrl_kill_enemies : BNE +
-    AND !ram_ctrl1_filtered : BEQ +
+  + LDA !IH_CONTROLLER_PRI : AND !sram_ctrl_kill_enemies : CMP !sram_ctrl_kill_enemies : BNE +
+    AND !IH_CONTROLLER_PRI_NEW : BEQ +
     JMP .kill_enemies
 
-  + LDA !ram_ctrl1 : AND !sram_ctrl_load_last_preset : CMP !sram_ctrl_load_last_preset : BNE +
-    AND !ram_ctrl1_filtered : BEQ +
+  + LDA !IH_CONTROLLER_PRI : AND !sram_ctrl_load_last_preset : CMP !sram_ctrl_load_last_preset : BNE +
+    AND !IH_CONTROLLER_PRI_NEW : BEQ +
     JMP .load_last_preset
 
-  + LDA !ram_ctrl1 : AND !sram_ctrl_reset_segment_timer : CMP !sram_ctrl_reset_segment_timer : BNE +
-    AND !ram_ctrl1_filtered : BEQ +
+  + LDA !IH_CONTROLLER_PRI : AND !sram_ctrl_reset_segment_timer : CMP !sram_ctrl_reset_segment_timer : BNE +
+    AND !IH_CONTROLLER_PRI_NEW : BEQ +
     JMP .reset_segment_timer
 
-  + LDA !ram_ctrl1 : AND !sram_ctrl_full_equipment : CMP !sram_ctrl_full_equipment : BNE +
-    AND !ram_ctrl1_filtered : BEQ +
+  + LDA !IH_CONTROLLER_PRI : AND !sram_ctrl_full_equipment : CMP !sram_ctrl_full_equipment : BNE +
+    AND !IH_CONTROLLER_PRI_NEW : BEQ +
     JMP .full_equipment
 
-  + LDA !ram_ctrl1 : AND !sram_ctrl_random_preset : CMP !sram_ctrl_random_preset : BNE +
-    AND !ram_ctrl1_filtered : BEQ +
+  + LDA !IH_CONTROLLER_PRI : AND !sram_ctrl_random_preset : CMP !sram_ctrl_random_preset : BNE +
+    AND !IH_CONTROLLER_PRI_NEW : BEQ +
     JMP .random_preset
 
-  + LDA !ram_ctrl1 : AND !sram_ctrl_menu : CMP !sram_ctrl_menu : BNE +
-    AND !ram_ctrl1_filtered : BEQ +
+  + LDA !IH_CONTROLLER_PRI : AND !sram_ctrl_menu : CMP !sram_ctrl_menu : BNE +
+    AND !IH_CONTROLLER_PRI_NEW : BEQ +
     JMP .menu
 
     ; No shortcuts matched, CLC so we won't skip normal gameplay

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -147,7 +147,7 @@ print pc, " infohud start"
 ih_max_etank_code:
 {
     ; Reset max-etanks value
-    LDA #$0000 : STA !ram_max_etanks
+    LDA #$0000 : STA !ram_etanks
     LDA $7EC200,X
     RTL
 }
@@ -457,11 +457,13 @@ ih_update_hud_code:
     ; Draw Item percent
     .pct
     {
-        LDA !sram_display_mode : CMP #$000E : BEQ .skipToEtanks
         LDA #$0000 : STA !ram_pct_1
 
         ; Max HP (E tanks)
         LDA $09C4 : JSR CalcEtank : LDA $4214 : STA !ram_etanks
+
+        ; skip item% if display mode = vspeed
+        LDA !sram_display_mode : CMP #$000E : BEQ .skipToEtanks
 
         ; Max Reserve Tanks
         LDA $09D4 : JSR CalcEtank
@@ -959,12 +961,10 @@ ih_game_loop_code:
 
   .update_status
     LDA #$0000
+    STA !ram_HUD_check
     STA !ram_armed_shine_duration
-    STA !ram_charge_counter
-    STA !ram_xfac_counter
     INC A
     STA !ram_dash_counter
-    STA !ram_iframe_counter
     STA !ram_xpos
     STA !ram_ypos
     STA !ram_horizontal_speed

--- a/src/infohudmodes.asm
+++ b/src/infohudmodes.asm
@@ -53,7 +53,7 @@ status_roomstrat:
 
 status_chargetimer:
 {
-    LDA #$003D : SEC : SBC $0CD0 : CMP !ram_charge_counter : BEQ .done : STA !ram_charge_counter
+    LDA #$003D : SEC : SBC $0CD0 : CMP !ram_HUD_check : BEQ .done : STA !ram_HUD_check
     CMP #$0000 : BPL .charging : LDA #$0000
 
   .charging
@@ -65,7 +65,7 @@ status_chargetimer:
 
 status_xfactor:
 {
-    LDA #$0079 : SEC : SBC $0CD0 : CMP !ram_xfac_counter : BEQ .done : STA !ram_xfac_counter
+    LDA #$0079 : SEC : SBC $0CD0 : CMP !ram_HUD_check : BEQ .done : STA !ram_HUD_check
     LDX #$0088 : JSR Draw4
 
   .done
@@ -74,7 +74,7 @@ status_xfactor:
 
 status_cooldowncounter:
 {
-    LDA $0CCC : CMP !ram_cooldown_counter : BEQ .done : STA !ram_cooldown_counter
+    LDA $0CCC : CMP !ram_HUD_check : BEQ .done : STA !ram_HUD_check
     LDX #$0088 : JSR Draw4
 
   .done
@@ -448,7 +448,7 @@ status_shinetune:
 
 status_iframecounter:
 {
-    LDA $18A8 : CMP !ram_iframe_counter : BEQ .done : STA !ram_iframe_counter
+    LDA $18A8 : CMP !ram_HUD_check : BEQ .done : STA !ram_HUD_check
     LDX #$0088 : JSR Draw4
 
   .done

--- a/src/init.asm
+++ b/src/init.asm
@@ -1,4 +1,4 @@
-!SRAM_VERSION = $0005
+!SRAM_VERSION = $0006
 
 
 ; hijack, runs as game is starting, JSR to RAM initialization to avoid bad values


### PR DESCRIPTION
- Reorder defines.asm to organize our RAM map
- Replace !ram_ctrl1 with !IH_CONTROLLER_PRI
- Share !ram_HUD_check for simple HUD modes
- Replace !ram_max_etanks with !ram_etanks
- Fix Etank counter when vspeed displayed

I've grouped up related RAM addresses and left some gaps between so we have an easier time inserting new ones and finding the next available address. Nearly all of the current addresses are in $B00-BFF, with the menu specific RAM and stack in F00+. I have a personal request that !ram_cgram_cache have a 30 byte allotment so my custom builds can keep all their master branch defines untouched. I'm using 20+ bytes here to customize more of the menu palettes.

Gamemodes.asm was using !ram_ctrl1 and !ram_ctrl1_filtered where everywhere else used !IH_CONTROLLER_PRI. They pointed to the same addresses ($8B and $8F) so I made it consistent and removed !ram_ctrl1. You may notice the savestate defines also have $8B and $8F defined with different names. I left those alone since the savestate code is meant to be ported to other games. (should they be moved into save.asm instead?)

There were a few very basic InfoHUD modes that store the drawn value to check if it needs to be redrawn next frame. These now use a common address (!ram_HUD_check) to store the drawn value. Couldn't think of a better name for it. Please suggest.

The ?? comments on !ram_etanks and !ram_max_etanks were likely because the max value was only ever zeroed and never used otherwise. It's gone now and only !ram_etanks is used.

I made a mistake when setting up the branch to skip item% code when Vspeed is enabled. It will now calculate etanks before trying to draw the value.