### PR TITLE
Preset scrolling fix + more early HUD updates

### DIFF
--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -140,6 +140,16 @@ org $AAE582      ; update timers when statue grabs Samus
 endif
     JSL ih_chozo_segment
 
+org $89AD0A      ; update timers when Samus escapes Ceres
+    JSL ih_ceres_elevator_segment
+
+if !FEATURE_PAL
+org $A2AA38
+else
+org $A2AA20      ; update timers when Samus enters ship
+endif
+    JSL ih_ship_elevator_segment
+
 
 ; Main bank stuff
 org $E08000
@@ -363,6 +373,18 @@ ih_chozo_segment:
 {
     JSL $8090CB ; overwritten code
     JML ih_update_hud_early
+}
+
+ih_ceres_elevator_segment:
+{
+    JSL ih_update_hud_early
+    JML $90F084 ; overwritten code
+}
+
+ih_ship_elevator_segment:
+{
+    JSL ih_update_hud_early
+    JML $91E3F6 ; overwritten code
 }
 
 ih_update_hud_code:

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -18,6 +18,9 @@ org $828115
 org $82EE92      ; runs on START GAME
     JSL startgame_seg_timer
 
+org $828B34      ; reset room timers for first room of Ceres
+    JML ceres_start_timers : NOP #2 : ceres_start_timers_return:
+        
 org $90E6AA      ; hijack, runs on gamestate = 08 (main gameplay), handles most updating HUD information
     JSL ih_gamemode_frame : NOP : NOP
 
@@ -328,6 +331,19 @@ ih_before_room_transition:
     STA $0998
     CLC
     RTL
+}
+
+ceres_start_timers:
+{
+    LDA #$0000
+    STA !ram_realtime_room : STA !ram_last_realtime_room
+    STA !ram_gametime_room : STA !ram_last_gametime_room
+    STA !ram_last_room_lag : STA !ram_last_door_lag_frames : STA !ram_transition_counter
+
+    STZ $0723 ; overwritten code
+    STZ $0725
+    
+    JML ceres_start_timers_return
 }
 
 ih_elevator_activation:

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -384,7 +384,11 @@ ih_ceres_elevator_segment:
 ih_ship_elevator_segment:
 {
     JSL ih_update_hud_early
+if !FEATURE_PAL
+    JML $91E35B ; overwritten code
+else
     JML $91E3F6 ; overwritten code
+endif
 }
 
 ih_update_hud_code:

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -162,7 +162,7 @@ MainMenu:
     dw #mm_goto_rngmenu
     dw #mm_goto_ctrlsmenu
     dw #$0000
-    %cm_header("SM PRACTICE HACK 2.2.5")
+    %cm_header("SM PRACTICE HACK 2.2.6")
 
 mm_goto_equipment:
     %cm_submenu("Equipment", #EquipmentMenu)

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -253,6 +253,7 @@ endif
     JSL $89AB82  ; Load FX1
     JSL $82E97C  ; Execute subroutine $82:E97C
 
+    JSR preset_scroll_fixes
     JSR $A2F9    ; Calculate layer 2 X position
     JSR $A33A    ; Calculate layer 2 Y position
     LDA $0917 : STA $0921  ; BG2 X scroll = layer 2 X scroll position
@@ -273,6 +274,29 @@ endif
     PLB
     PLP
     RTL
+}
+
+preset_scroll_fixes:
+{
+    PHP : %a8() : %i16()
+    ; run every preset with red (0) in $24
+    LDA $7ECD24 : BNE +
+    LDA #$01
+    STA $7ECD24
+    ; room-specific fixes
++   LDX $079B : LDA #$01
+    CPX #$B07A : BNE + ; top of Bat Cave
+    STA $7ECD20
++   CPX #$A011 : BNE + ; bottom-left of Etecoons Etank
+    STA $7ECD25
+    STA $7ECD26
++   CPX #$B3A5 : BNE + ; bottom of Pre-Pillars
+    STA $7ECD22
+    LDA #$00
+    STA $7ECD21
+
++   PLP
+    RTS
 }
 
 transfer_cgram_long:

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -281,21 +281,25 @@ preset_scroll_fixes:
     PHP : %a8() : %i16()
     ; run every preset with red (0) in $24
     LDA $7ECD24 : BNE +
-    LDA #$01
-    STA $7ECD24
+    LDA #$01 : STA $7ECD24
     ; room-specific fixes
 +   LDX $079B : LDA #$01
     CPX #$B07A : BNE + ; top of Bat Cave
     STA $7ECD20
+    BRA .done
 +   CPX #$A011 : BNE + ; bottom-left of Etecoons Etank
-    STA $7ECD25
-    STA $7ECD26
-+   CPX #$B3A5 : BNE + ; bottom of Pre-Pillars
+    STA $7ECD25 : STA $7ECD26
+    BRA .done
++   CPX #$B1E5 : BNE + ; bottom of Acid Chozo room
+    STA $7ECD26 : STA $7ECD27 : STA $7ECD28
+    LDA #$00 : STA $7ECD23 : STA $7ECD24
+    BRA .done
++   CPX #$B3A5 : BNE .done ; bottom of Pre-Pillars
     STA $7ECD22
-    LDA #$00
-    STA $7ECD21
+    LDA #$00 : STA $7ECD21
 
-+   PLP
+  .done
+    PLP
     RTS
 }
 

--- a/website/ClientApp/src/components/Changelog.js
+++ b/website/ClientApp/src/components/Changelog.js
@@ -42,6 +42,7 @@ export class Changelog extends Component {
                                                 <li>Allow GT Max% equipment levels. (2.2.4)</li>
                                                 <li>CPU% calcalation now includes the artifical lag. (2.2.4)</li>
                                                 <li>Restored room timers while minimap is enabled. (2.2.5)</li>
+                                                <li>Update HUD timers on Ceres elevator and ship entry. (2.2.6)</li>
                                             </ul>
                                         </CardBody>
                                     </Card>

--- a/website/ClientApp/src/components/Changelog.js
+++ b/website/ClientApp/src/components/Changelog.js
@@ -42,6 +42,7 @@ export class Changelog extends Component {
                                                 <li>Allow GT Max% equipment levels. (2.2.4)</li>
                                                 <li>CPU% calcalation now includes the artifical lag. (2.2.4)</li>
                                                 <li>Restored room timers while minimap is enabled. (2.2.5)</li>
+                                                <li>Fix bad camera scroll after loading certain presets. (2.2.6)</li>
                                                 <li>Update HUD timers on Ceres elevator and ship entry. (2.2.6)</li>
                                             </ul>
                                         </CardBody>

--- a/website/ClientApp/src/components/Home.js
+++ b/website/ClientApp/src/components/Home.js
@@ -10,7 +10,7 @@ export class Home extends Component {
       <Row className="justify-content-center">
         <Col md="8">
           <div>
-              <Patcher version="2.2.5"/>
+              <Patcher version="2.2.6"/>
           </div>
         </Col>
       </Row>


### PR DESCRIPTION
Just a couple more places to update the HUD early: Ceres escape elevator and facing forward on the ship. The ship update runs anytime you press down to go in the ship, not just the escape. Ceres elevator didn't need a separate address for PAL.