### PR TITLE
Preserve layer 2 offsets in presets

### DIFF
--- a/src/custompresets.asm
+++ b/src/custompresets.asm
@@ -7,445 +7,139 @@ custom_preset_save:
 {
     LDA !sram_custom_preset_slot
     ASL : XBA : TAX ; multiply by 200h (slot offset)
-    LDA #$5AFE : STA $703000,X : INX #2 ; mark this slot as "SAFE" to load
-    LDA #$01B0 : STA $703000,X : INX #2 ; record slot size for future compatibility
-    LDA $078B : STA $703000,X : INX #2 ;  Elevator Index
-    LDA $078D : STA $703000,X : INX #2 ;  DDB
-    LDA $078F : STA $703000,X : INX #2 ;  DoorOut Index
-    LDA $079B : STA $703000,X : INX #2 ;  MDB
-    LDA $079F : STA $703000,X : INX #2 ;  Region
-    LDA $07C3 : STA $703000,X : INX #2 ;  GFX Pointers
-    LDA $07C5 : STA $703000,X : INX #2 ;  GFX Pointers
-    LDA $07C7 : STA $703000,X : INX #2 ;  GFX Pointers
-    LDA $07F3 : STA $703000,X : INX #2 ;  Music Bank
-    LDA $07F5 : STA $703000,X : INX #2 ;  Music Track
-    LDA $090F : STA $703000,X : INX #2 ;  Screen subpixel X position
-    LDA $0911 : STA $703000,X : INX #2 ;  Screen X position in pixels
-    LDA $0913 : STA $703000,X : INX #2 ;  Screen subpixel Y position
-    LDA $0915 : STA $703000,X : INX #2 ;  Screen Y position in pixels
-    LDA $093F : STA $703000,X : INX #2 ;  Ceres escape flag
-    LDA $09A2 : STA $703000,X : INX #2 ;  Equipped Items
-    LDA $09A4 : STA $703000,X : INX #2 ;  Collected Items
-    LDA $09A6 : STA $703000,X : INX #2 ;  Beams
-    LDA $09A8 : STA $703000,X : INX #2 ;  Beams
-    LDA $09C0 : STA $703000,X : INX #2 ;  Manual/Auto reserve tank
-    LDA $09C2 : STA $703000,X : INX #2 ;  Health
-    LDA $09C4 : STA $703000,X : INX #2 ;  Max health
-    LDA $09C6 : STA $703000,X : INX #2 ;  Missiles
-    LDA $09C8 : STA $703000,X : INX #2 ;  Max missiles
-    LDA $09CA : STA $703000,X : INX #2 ;  Supers
-    LDA $09CC : STA $703000,X : INX #2 ;  Max supers
-    LDA $09CE : STA $703000,X : INX #2 ;  Pbs
-    LDA $09D0 : STA $703000,X : INX #2 ;  Max pbs
-    LDA $09D2 : STA $703000,X : INX #2 ;  Currently selected item
-    LDA $09D4 : STA $703000,X : INX #2 ;  Max reserves
-    LDA $09D6 : STA $703000,X : INX #2 ;  Reserves
-    LDA $0A1C : STA $703000,X : INX #2 ;  Samus position/state
-    LDA $0A1E : STA $703000,X : INX #2 ;  More position/state
-    LDA $0A68 : STA $703000,X : INX #2 ;  Flash suit
-    LDA $0A76 : STA $703000,X : INX #2 ;  Hyper beam
-    LDA $0AF6 : STA $703000,X : INX #2 ;  Samus X
-    LDA $0AFA : STA $703000,X : INX #2 ;  Samus Y
-    LDA $0B3F : STA $703000,X : INX #2 ;  Blue suit
-    LDA $7ED7C0 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7C2 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7C4 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7C6 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7C8 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7CA : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7CC : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7CE : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7D0 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7D2 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7D4 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7D6 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7D8 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7DA : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7DC : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7DE : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7E0 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7E2 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7E4 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7E6 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7E8 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7EA : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7EC : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7EE : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7F0 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7F2 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7F4 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7F6 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7F8 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7FA : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7FC : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED7FE : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED800 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED802 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED804 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED806 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED808 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED80A : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED80C : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED80E : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED810 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED812 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED814 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED816 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED818 : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED81A : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED81C : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED81E : STA $703000,X : INX #2 ;  SRAM copy
-    LDA $7ED820 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED822 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED824 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED826 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED828 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED82A : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED82C : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED82E : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED830 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED832 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED834 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED836 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED838 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED83A : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED83C : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED83E : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED840 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED842 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED844 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED846 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED848 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED84A : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED84C : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED84E : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED850 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED852 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED854 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED856 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED858 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED85A : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED85C : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED85E : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED860 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED862 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED864 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED866 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED868 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED86A : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED86C : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED86E : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED870 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED872 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED874 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED876 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED878 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED87A : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED87C : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED87E : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED880 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED882 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED884 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED886 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED888 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED88A : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED88C : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED88E : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED890 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED892 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED894 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED896 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED898 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED89A : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED89C : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED89E : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8A0 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8A2 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8A4 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8A6 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8A8 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8AA : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8AC : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8AE : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8B0 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8B2 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8B4 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8B6 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8B8 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8BA : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8BC : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8BE : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8C0 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8C2 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8C4 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8C6 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8C8 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8CA : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8CC : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8CE : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8D0 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8D2 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8D4 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8D6 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8D8 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8DA : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8DC : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8DE : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8E0 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8E2 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8E4 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8E6 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8E8 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8EA : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8EC : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8EE : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8F0 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8F2 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8F4 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8F6 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8F8 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8FA : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8FC : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED8FE : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED900 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED902 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED904 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED906 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED908 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED90A : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED90C : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED90E : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED910 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED912 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED914 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED916 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED918 : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED91A : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED91C : STA $703000,X : INX #2 ;  Events, Items, Doors
-    LDA $7ED91E : STA $703000,X : INX #2 ;  Events, Items, Doors
+    LDA #$5AFE : STA $703000,X   ; mark this slot as "SAFE" to load
+    LDA #$01B8 : STA $703002,X   ; record slot size for future compatibility
+    LDA $078B : STA $703004,X    ; Elevator Index
+    LDA $078D : STA $703006,X    ; DDB
+    LDA $078F : STA $703008,X    ; DoorOut Index
+    LDA $079B : STA $70300A,X    ; MDB
+    LDA $079F : STA $70300C,X    ; Region
+    LDA $07C3 : STA $70300E,X    ; GFX Pointers
+    LDA $07C5 : STA $703010,X    ; GFX Pointers
+    LDA $07C7 : STA $703012,X    ; GFX Pointers
+    LDA $07F3 : STA $703014,X    ; Music Bank
+    LDA $07F5 : STA $703016,X    ; Music Track
+    LDA $090F : STA $703018,X    ; Screen subpixel X position
+    LDA $0911 : STA $70301A,X    ; Screen X position in pixels
+    LDA $0913 : STA $70301C,X    ; Screen subpixel Y position
+    LDA $0915 : STA $70301E,X    ; Screen Y position in pixels
+    LDA $093F : STA $703020,X    ; Ceres escape flag
+    LDA $09A2 : STA $703022,X    ; Equipped Items
+    LDA $09A4 : STA $703024,X    ; Collected Items
+    LDA $09A6 : STA $703026,X    ; Beams
+    LDA $09A8 : STA $703028,X    ; Beams
+    LDA $09C0 : STA $70302A,X    ; Manual/Auto reserve tank
+    LDA $09C2 : STA $70302C,X    ; Health
+    LDA $09C4 : STA $70302E,X    ; Max health
+    LDA $09C6 : STA $703030,X    ; Missiles
+    LDA $09C8 : STA $703032,X    ; Max missiles
+    LDA $09CA : STA $703034,X    ; Supers
+    LDA $09CC : STA $703036,X    ; Max supers
+    LDA $09CE : STA $703038,X    ; Pbs
+    LDA $09D0 : STA $70303A,X    ; Max pbs
+    LDA $09D2 : STA $70303C,X    ; Currently selected item
+    LDA $09D4 : STA $70303E,X    ; Max reserves
+    LDA $09D6 : STA $703040,X    ; Reserves
+    LDA $0A1C : STA $703042,X    ; Samus position/state
+    LDA $0A1E : STA $703044,X    ; More position/state
+    LDA $0A68 : STA $703046,X    ; Flash suit
+    LDA $0A76 : STA $703048,X    ; Hyper beam
+    LDA $0AF6 : STA $70304A,X    ; Samus X
+    LDA $0AFA : STA $70304C,X    ; Samus Y
+    LDA $0B3F : STA $70304E,X    ; Blue suit
+
+    ; Copy SRAM
+    TXA : CLC : ADC #$005F : TAX
+  .save_sram_loop
+    DEX : PHX : TXA : AND #$01FF : TAX
+    LDA $7ED7C0,X : PLX : STA $703050,X
+    DEX : TXA : BIT #$0100 : BEQ .save_sram_loop
+
+    ; Copy Events, Items, Doors
+    CLC : ADC #$0100 : TAX
+  .save_events_items_doors_loop
+    DEX : PHX : TXA : AND #$01FF : TAX
+    LDA $7ED820,X : PLX : STA $7030B0,X
+    DEX : TXA : BIT #$0100 : BEQ .save_events_items_doors_loop
+
+    INX                          ; Restore X for sanity
+    LDA $0917 : STA $7031B0,X    ; Layer 2 X position
+    LDA $0919 : STA $7031B2,X    ; Layer 2 Y position
+    LDA $0921 : STA $7031B4,X    ; BG2 X offset
+    LDA $0923 : STA $7031B6,X    ; BG2 Y offset
     RTL
 }
 
 custom_preset_load:
 {
     LDA !sram_custom_preset_slot
-    ASL : XBA : TAX ; multiply by 200h
-    INX #2 ; skip past "5AFE" word
-    INX #2 ; skip past size for now
-    LDA $703000,X : STA $078B : INX #2 ;  Elevator Index
-    LDA $703000,X : STA $078D : INX #2 ;  DDB
-    LDA $703000,X : STA $078F : INX #2 ;  DoorOut Index
-    LDA $703000,X : STA $079B : INX #2 ;  MDB
-    LDA $703000,X : STA $079F : INX #2 ;  Region
-    LDA $703000,X : STA $07C3 : INX #2 ;  GFX Pointers
-    LDA $703000,X : STA $07C5 : INX #2 ;  GFX Pointers
-    LDA $703000,X : STA $07C7 : INX #2 ;  GFX Pointers
-    LDA $703000,X : STA $07F3 : INX #2 ;  Music Bank
-    LDA $703000,X : STA $07F5 : INX #2 ;  Music Track
-    LDA $703000,X : STA $090F : INX #2 ;  Screen subpixel X position
-    LDA $703000,X : STA $0911 : INX #2 ;  Screen X position in pixels
-    LDA $703000,X : STA $0913 : INX #2 ;  Screen subpixel Y position
-    LDA $703000,X : STA $0915 : INX #2 ;  Screen Y position in pixels
-    LDA $703000,X : STA $093F : INX #2 ;  Ceres escape flag
-    LDA $703000,X : STA $09A2 : INX #2 ;  Equipped Items
-    LDA $703000,X : STA $09A4 : INX #2 ;  Collected Items
-    LDA $703000,X : STA $09A6 : INX #2 ;  Beams
-    LDA $703000,X : STA $09A8 : INX #2 ;  Beams
-    LDA $703000,X : STA $09C0 : INX #2 ;  Manual/Auto reserve tank
-    LDA $703000,X : STA $09C2 : INX #2 ;  Health
-    LDA $703000,X : STA $09C4 : INX #2 ;  Max health
-    LDA $703000,X : STA $09C6 : INX #2 ;  Missiles
-    LDA $703000,X : STA $09C8 : INX #2 ;  Max missiles
-    LDA $703000,X : STA $09CA : INX #2 ;  Supers
-    LDA $703000,X : STA $09CC : INX #2 ;  Max supers
-    LDA $703000,X : STA $09CE : INX #2 ;  Pbs
-    LDA $703000,X : STA $09D0 : INX #2 ;  Max pbs
-    LDA $703000,X : STA $09D2 : INX #2 ;  Currently selected item
-    LDA $703000,X : STA $09D4 : INX #2 ;  Max reserves
-    LDA $703000,X : STA $09D6 : INX #2 ;  Reserves
-    LDA $703000,X : STA $0A1C : INX #2 ;  Samus position/state
-    LDA $703000,X : STA $0A1E : INX #2 ;  More position/state
-    LDA $703000,X : STA $0A68 : INX #2 ;  Flash suit
-    LDA $703000,X : STA $0A76 : INX #2 ;  Hyper beam
-    LDA $703000,X : STA $0AF6 : INX #2 ;  Samus X
-    LDA $703000,X : STA $0AFA : INX #2 ;  Samus Y
-    LDA $703000,X : STA $0B3F : INX #2 ;  Blue suit
-    LDA $703000,X : STA $7ED7C0 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7C2 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7C4 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7C6 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7C8 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7CA : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7CC : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7CE : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7D0 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7D2 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7D4 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7D6 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7D8 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7DA : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7DC : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7DE : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7E0 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7E2 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7E4 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7E6 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7E8 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7EA : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7EC : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7EE : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7F0 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7F2 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7F4 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7F6 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7F8 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7FA : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7FC : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED7FE : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED800 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED802 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED804 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED806 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED808 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED80A : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED80C : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED80E : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED810 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED812 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED814 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED816 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED818 : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED81A : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED81C : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED81E : INX #2 ;  SRAM copy
-    LDA $703000,X : STA $7ED820 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED822 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED824 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED826 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED828 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED82A : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED82C : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED82E : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED830 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED832 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED834 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED836 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED838 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED83A : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED83C : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED83E : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED840 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED842 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED844 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED846 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED848 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED84A : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED84C : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED84E : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED850 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED852 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED854 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED856 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED858 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED85A : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED85C : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED85E : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED860 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED862 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED864 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED866 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED868 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED86A : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED86C : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED86E : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED870 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED872 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED874 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED876 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED878 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED87A : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED87C : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED87E : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED880 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED882 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED884 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED886 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED888 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED88A : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED88C : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED88E : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED890 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED892 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED894 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED896 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED898 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED89A : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED89C : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED89E : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8A0 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8A2 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8A4 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8A6 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8A8 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8AA : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8AC : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8AE : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8B0 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8B2 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8B4 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8B6 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8B8 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8BA : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8BC : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8BE : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8C0 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8C2 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8C4 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8C6 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8C8 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8CA : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8CC : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8CE : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8D0 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8D2 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8D4 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8D6 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8D8 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8DA : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8DC : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8DE : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8E0 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8E2 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8E4 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8E6 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8E8 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8EA : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8EC : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8EE : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8F0 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8F2 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8F4 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8F6 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8F8 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8FA : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8FC : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED8FE : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED900 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED902 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED904 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED906 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED908 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED90A : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED90C : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED90E : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED910 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED912 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED914 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED916 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED918 : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED91A : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED91C : INX #2 ;  Events, Items, Doors
-    LDA $703000,X : STA $7ED91E : INX #2 ;  Events, Items, Doors
+    ASL : XBA : TAX              ; multiply by 200h
+                                 ; skip past "5AFE" word
+                                 ; skip past size for now
+    LDA $703004,X : STA $078B    ; Elevator Index
+    LDA $703006,X : STA $078D    ; DDB
+    LDA $703008,X : STA $078F    ; DoorOut Index
+    LDA $70300A,X : STA $079B    ; MDB
+    LDA $70300C,X : STA $079F    ; Region
+    LDA $70300E,X : STA $07C3    ; GFX Pointers
+    LDA $703010,X : STA $07C5    ; GFX Pointers
+    LDA $703012,X : STA $07C7    ; GFX Pointers
+    LDA $703014,X : STA $07F3    ; Music Bank
+    LDA $703016,X : STA $07F5    ; Music Track
+    LDA $703018,X : STA $090F    ; Screen subpixel X position
+    LDA $70301A,X : STA $0911    ; Screen X position in pixels
+    LDA $70301C,X : STA $0913    ; Screen subpixel Y position
+    LDA $70301E,X : STA $0915    ; Screen Y position in pixels
+    LDA $703020,X : STA $093F    ; Ceres escape flag
+    LDA $703022,X : STA $09A2    ; Equipped Items
+    LDA $703024,X : STA $09A4    ; Collected Items
+    LDA $703026,X : STA $09A6    ; Beams
+    LDA $703028,X : STA $09A8    ; Beams
+    LDA $70302A,X : STA $09C0    ; Manual/Auto reserve tank
+    LDA $70302C,X : STA $09C2    ; Health
+    LDA $70302E,X : STA $09C4    ; Max health
+    LDA $703030,X : STA $09C6    ; Missiles
+    LDA $703032,X : STA $09C8    ; Max missiles
+    LDA $703034,X : STA $09CA    ; Supers
+    LDA $703036,X : STA $09CC    ; Max supers
+    LDA $703038,X : STA $09CE    ; Pbs
+    LDA $70303A,X : STA $09D0    ; Max pbs
+    LDA $70303C,X : STA $09D2    ; Currently selected item
+    LDA $70303E,X : STA $09D4    ; Max reserves
+    LDA $703040,X : STA $09D6    ; Reserves
+    LDA $703042,X : STA $0A1C    ; Samus position/state
+    LDA $703044,X : STA $0A1E    ; More position/state
+    LDA $703046,X : STA $0A68    ; Flash suit
+    LDA $703048,X : STA $0A76    ; Hyper beam
+    LDA $70304A,X : STA $0AF6    ; Samus X
+    LDA $70304C,X : STA $0AFA    ; Samus Y
+    LDA $70304E,X : STA $0B3F    ; Blue suit
+
+    ; Copy SRAM
+    TXA : CLC : ADC #$005F : TAX
+  .load_sram_loop
+    DEX : LDA $703050,X : PHX : PHA
+    TXA : AND #$01FF : TAX : PLA
+    STA $7ED7C0,X : PLX
+    DEX : TXA : BIT #$0100 : BEQ .load_sram_loop
+
+    ; Copy Events, Items, Doors
+    CLC : ADC #$0100 : TAX
+  .load_events_items_doors_loop
+    DEX : LDA $7030B0,X : PHX : PHA
+    TXA : AND #$01FF : TAX : PLA
+    STA $7ED820,X : PLX
+    DEX : TXA : BIT #$0100 : BEQ .load_events_items_doors_loop
+
+    ; Restore X for sanity, then check if we have layer 2 values
+    INX : LDA $703002,X : CMP #$01B0 : BEQ .done_loading
+
+    LDA $7031B0,X : STA $0917    ; Layer 2 X position
+    LDA $7031B2,X : STA $0919    ; Layer 2 Y position
+    LDA $7031B4,X : STA $0921    ; BG2 X offset
+    LDA $7031B6,X : STA $0923    ; BG2 Y offset
+
+  .done_loading
     LDA #$0000 : STA !ram_custom_preset
     RTL
 }

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -258,6 +258,7 @@ preset_room_setup_asm_fixes:
     LDA $0998 : CMP #$0006 : BEQ .execute_setup_asm
     CMP #$001F : BEQ .execute_setup_asm
     CMP #$0028 : BEQ .execute_setup_asm
+    STZ $07DF
     BRA .end
 }
 

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -259,6 +259,7 @@ preset_room_setup_asm_fixes:
     CMP #$001F : BEQ .execute_setup_asm
     CMP #$0028 : BEQ .execute_setup_asm
     STZ $07DF
+    LDA #$0080 : STA $091B
     BRA .end
 }
 

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -228,6 +228,42 @@ preset_banks:
 print pc, " presets end"
 
 
+org $82E8D9
+    JSL preset_room_setup_asm_fixes
+
+
+org $8FEB00
+print pc, " preset bank8F start"
+
+preset_room_setup_asm_fixes:
+{
+    ; Start with original logic
+    PHP : PHB
+    %ai16()
+    LDX $07BB
+    LDA $0018,X : BEQ .end
+
+    ; Check if this is scrolling sky
+    CMP #$91C9 : BEQ .scrolling_sky
+    CMP #$91CE : BEQ .scrolling_sky
+
+  .execute_setup_asm
+    PHK : PLB
+    JSR ($0018,X)
+
+  .end
+    PLB : PLP : RTL
+
+  .scrolling_sky
+    LDA $0998 : CMP #$0006 : BEQ .execute_setup_asm
+    CMP #$001F : BEQ .execute_setup_asm
+    CMP #$0028 : BEQ .execute_setup_asm
+    BRA .end
+}
+
+print pc, " preset bank8F end"
+
+
 org $80F000
 print pc, " preset_start_gameplay start"
 


### PR DESCRIPTION
This should allow existing presets and custom presets to work, but also allow new custom presets to maintain the BG2 layer positioning.  It's more noticeable in places like Wrecked Ship or Tourian (e.g. zeb skip preset).  Eventually we should also add BG2 to the existing presets but that may take some time; I'm planning to ask for help from the community.

This is hot-off-the-press.  I'd like to clean up the code a bit, add some comments, not sure how I feel about the custom preset logic loops I added but they work and it's less code.  I didn't like the INX 2 everywhere so I am (mostly) maintaining X where it is.  This also helps so I can look up the size (at beginning of data) when deciding if I want to load BG2 (from the end of the data).

Also unfortunately this is did not fix the bowling room.  In particular the Pancakes and Wavers preset, which looks wrong when you load it (background is dark).  You can exit/reenter the room and it fixes the background, but when you get to bowling it is messed up.  However if you load the Bowling preset, the bowling room works.  It's rather strange.  Even with my improvements, custom presets do the same thing when set at the Pancakes and Wavers position.