### PR TITLE
Add toggles for individual Phantoon patterns (#62)

### DIFF
--- a/src/defines.asm
+++ b/src/defines.asm
@@ -64,11 +64,11 @@
 !ram_room_has_set_rng = !WRAM_START+$5A
 !ram_kraid_rng = !WRAM_START+$5C
 !ram_crocomire_rng = !WRAM_START+$5E
-!ram_phantoon_rng_1 = !WRAM_START+$60
-!ram_phantoon_rng_2 = !WRAM_START+$62
-!ram_phantoon_rng_3 = !WRAM_START+$64
-!ram_phantoon_rng_4 = !WRAM_START+$66
-!ram_phantoon_rng_5 = !WRAM_START+$68
+!ram_phantoon_rng_1 = !WRAM_START+$60 ; round 1 pattern bitmask
+!ram_phantoon_rng_2 = !WRAM_START+$62 ; round 2 pattern bitmask
+!ram_phantoon_rng_3 = !WRAM_START+$64 ; eye close
+!ram_phantoon_rng_4 = !WRAM_START+$66 ; flames
+!ram_phantoon_rng_5 = !WRAM_START+$68 ; next flame
 !ram_botwoon_rng = !WRAM_START+$6A
 !ram_draygon_rng_left = !WRAM_START+$6C
 !ram_draygon_rng_right = !WRAM_START+$6E
@@ -401,6 +401,7 @@
 !CUTSCENE_SKIP_CERES_ARRIVAL = #$0002
 !CUTSCENE_SKIP_G4 = #$0080
 !CUTSCENE_FAST_MB = #$0100
+!CUTSCENE_FAST_PHANTOON = #$0200
 
 !COMPRESSED_GRAPHICS = #$0001
 !COMPRESSED_PALETTES = #$0002

--- a/src/init.asm
+++ b/src/init.asm
@@ -73,7 +73,6 @@ init_nonzero_wram:
     ; RAM $7E0000 fluctuates so it is not a good default value
     LDA #$0F8C : STA !ram_watch_left        ; Enemy HP
     LDA #$09C2 : STA !ram_watch_right       ; Samus HP
-    LDA #$003F : STA !ram_phantoon_rng_1    ; Enable all Phantoon patterns
 
     ; Check if any less common controller shortcuts are configured
     JML GameModeExtras

--- a/src/init.asm
+++ b/src/init.asm
@@ -71,8 +71,9 @@ init_nonzero_wram:
     JSL init_wram_based_on_sram
 
     ; RAM $7E0000 fluctuates so it is not a good default value
-    LDA #$0F8C : STA !ram_watch_left   ; Enemy HP
-    LDA #$09C2 : STA !ram_watch_right  ; Samus HP
+    LDA #$0F8C : STA !ram_watch_left        ; Enemy HP
+    LDA #$09C2 : STA !ram_watch_right       ; Samus HP
+    LDA #$003F : STA !ram_phantoon_rng_1    ; Enable all Phantoon patterns
 
     ; Check if any less common controller shortcuts are configured
     JML GameModeExtras

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -1670,6 +1670,7 @@ CutscenesMenu:
     dw #cutscenes_skip_ceres_arrival
     dw #cutscenes_skip_g4
     dw #$FFFF
+    dw #cutscenes_fast_phantoon
     dw #cutscenes_fast_mb
     dw #$0000
     %cm_header("CUTSCENES")
@@ -1683,9 +1684,11 @@ cutscenes_skip_ceres_arrival:
 cutscenes_skip_g4:
     %cm_toggle_bit("Skip G4", !sram_cutscenes, !CUTSCENE_SKIP_G4, #0)
 
+cutscenes_fast_phantoon:
+    %cm_toggle_bit("Fast Phantoon Entry", !sram_cutscenes, !CUTSCENE_FAST_PHANTOON, #0)
+
 cutscenes_fast_mb:
     %cm_toggle_bit("Fast Mother Brain", !sram_cutscenes, !CUTSCENE_FAST_MB, #0)
-
 
 game_fanfare_toggle:
     %cm_toggle("Fanfare", !sram_fanfare_toggle, #$0001, #0)
@@ -2158,36 +2161,64 @@ rng_kraid_rng:
 ; Phantoon Menu
 ; --------------
 PhantoonMenu:
-    dw #phan_fast_left
-    dw #phan_mid_left
-    dw #phan_slow_left
-    dw #phan_fast_right
-    dw #phan_mid_right
-    dw #phan_slow_right
+    dw #phan_fast_left_1
+    dw #phan_mid_left_1
+    dw #phan_slow_left_1
+    dw #phan_fast_right_1
+    dw #phan_mid_right_1
+    dw #phan_slow_right_1
+    dw #$FFFF
+    dw #phan_fast_left_2
+    dw #phan_mid_left_2
+    dw #phan_slow_left_2
+    dw #phan_fast_right_2
+    dw #phan_mid_right_2
+    dw #phan_slow_right_2
+    dw #$FFFF
     dw #phan_eyeclose
     dw #phan_flamepattern
     dw #phan_next_flamepattern
-    dw #phan_skip_intro
     dw #$0000
     %cm_header("PHANTOON CONTROL")
 
-phan_fast_left:
-    %cm_toggle_bit("Fast Left", !ram_phantoon_rng_1, #$0020, 0)
 
-phan_mid_left:
-    %cm_toggle_bit(" Mid Left", !ram_phantoon_rng_1, #$0008, 0)
+phan_fast_left_1:
+    %cm_toggle_bit("#1 Fast Left", !ram_phantoon_rng_1, #$0020, 0)
 
-phan_slow_left:
-    %cm_toggle_bit("Slow Left", !ram_phantoon_rng_1, #$0002, 0)
+phan_mid_left_1:
+    %cm_toggle_bit("#1 Mid  Left", !ram_phantoon_rng_1, #$0008, 0)
 
-phan_fast_right:
-    %cm_toggle_bit("Fast Right", !ram_phantoon_rng_1, #$0010, 0)
+phan_slow_left_1:
+    %cm_toggle_bit("#1 Slow Left", !ram_phantoon_rng_1, #$0002, 0)
 
-phan_mid_right:
-    %cm_toggle_bit(" Mid Right", !ram_phantoon_rng_1, #$0004, 0)
+phan_fast_right_1:
+    %cm_toggle_bit("#1 Fast Right", !ram_phantoon_rng_1, #$0010, 0)
 
-phan_slow_right:
-    %cm_toggle_bit("Slow Right", !ram_phantoon_rng_1, #$0001, 0)
+phan_mid_right_1:
+    %cm_toggle_bit("#1 Mid  Right", !ram_phantoon_rng_1, #$0004, 0)
+
+phan_slow_right_1:
+    %cm_toggle_bit("#1 Slow Right", !ram_phantoon_rng_1, #$0001, 0)
+
+
+phan_fast_left_2:
+    %cm_toggle_bit("#2 Fast Left", !ram_phantoon_rng_2, #$0020, 0)
+
+phan_mid_left_2:
+    %cm_toggle_bit("#2 Mid  Left", !ram_phantoon_rng_2, #$0008, 0)
+
+phan_slow_left_2:
+    %cm_toggle_bit("#2 Slow Left", !ram_phantoon_rng_2, #$0002, 0)
+
+phan_fast_right_2:
+    %cm_toggle_bit("#2 Fast Right", !ram_phantoon_rng_2, #$0010, 0)
+
+phan_mid_right_2:
+    %cm_toggle_bit("#2 Mid  Right", !ram_phantoon_rng_2, #$0004, 0)
+
+phan_slow_right_2:
+    %cm_toggle_bit("#2 Slow Right", !ram_phantoon_rng_2, #$0001, 0)
+
 
 phan_eyeclose:
     dw !ACTION_CHOICE
@@ -2223,9 +2254,6 @@ phan_next_flamepattern:
     db #$28, "    3333333", #$FF
     db #$28, "    1424212", #$FF
     db #$FF
-
-phan_skip_intro:
-    %cm_toggle_bit("Skip Intro", !ram_phantoon_rng_2, #$0001, 0)
 
 ; ----------
 ; Ctrl Menu

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -2077,11 +2077,7 @@ RngMenu:
     if !FEATURE_SD2SNES
         dw #rng_rerandomize
     endif
-    dw #rng_phan_first_phase
-    dw #rng_phan_second_phase
-    dw #rng_phan_eyeclose
-    dw #rng_phan_flamepattern
-    dw #rng_next_flamepattern
+    dw #rng_goto_phanmenu
     dw #$FFFF
     dw #rng_botwoon_rng
     dw #$FFFF
@@ -2097,68 +2093,8 @@ RngMenu:
 rng_rerandomize:
     %cm_toggle("Rerandomize", !sram_rerandomize, #$0001, #0)
 
-rng_phan_first_phase:
-    dw !ACTION_CHOICE
-    dl #!ram_phantoon_rng_1
-    dw #$0000
-    db #$28, "Phan 1st Phase", #$FF
-    db #$28, "     RANDOM", #$FF
-    db #$28, "  FAST LEFT", #$FF
-    db #$28, "   MID LEFT", #$FF
-    db #$28, "  SLOW LEFT", #$FF
-    db #$28, " FAST RIGHT", #$FF
-    db #$28, "  MID RIGHT", #$FF
-    db #$28, " SLOW RIGHT", #$FF
-    db #$FF
-
-rng_phan_second_phase:
-    dw !ACTION_CHOICE
-    dl #!ram_phantoon_rng_2
-    dw #$0000
-    db #$28, "Phan 2nd Phase", #$FF
-    db #$28, "     RANDOM", #$FF
-    db #$28, "  FAST LEFT", #$FF
-    db #$28, "   MID LEFT", #$FF
-    db #$28, "  SLOW LEFT", #$FF
-    db #$28, " FAST RIGHT", #$FF
-    db #$28, "  MID RIGHT", #$FF
-    db #$28, " SLOW RIGHT", #$FF
-    db #$FF
-
-rng_phan_eyeclose:
-    dw !ACTION_CHOICE
-    dl #!ram_phantoon_rng_3
-    dw #$0000
-    db #$28, "Phan Eye Close", #$FF
-    db #$28, "     RANDOM", #$FF
-    db #$28, "       SLOW", #$FF
-    db #$28, "        MID", #$FF
-    db #$28, "       FAST", #$FF
-    db #$FF
-
-rng_phan_flamepattern:
-    dw !ACTION_CHOICE
-    dl #!ram_phantoon_rng_4
-    dw #$0000
-    db #$28, "Phan Flames   ", #$FF
-    db #$28, "     RANDOM", #$FF
-    db #$28, "      22222", #$FF
-    db #$28, "        111", #$FF
-    db #$28, "    3333333", #$FF
-    db #$28, "    1424212", #$FF
-    db #$FF
-
-rng_next_flamepattern:
-    dw !ACTION_CHOICE
-    dl #!ram_phantoon_rng_5
-    dw #$0000
-    db #$28, "Next Flames   ", #$FF
-    db #$28, "     RANDOM", #$FF
-    db #$28, "      22222", #$FF
-    db #$28, "        111", #$FF
-    db #$28, "    3333333", #$FF
-    db #$28, "    1424212", #$FF
-    db #$FF
+rng_goto_phanmenu:
+    %cm_submenu("Phantoon", #PhantoonMenu)
 
 rng_botwoon_rng:
     dw !ACTION_CHOICE
@@ -2217,6 +2153,75 @@ rng_kraid_rng:
     db #$28, "    LAGGIER", #$FF
     db #$FF
 
+
+; --------------
+; Phantoon Menu
+; --------------
+PhantoonMenu:
+    dw #phan_fast_left
+    dw #phan_mid_left
+    dw #phan_slow_left
+    dw #phan_fast_right
+    dw #phan_mid_right
+    dw #phan_slow_right
+    dw #phan_eyeclose
+    dw #phan_flamepattern
+    dw #phan_next_flamepattern
+    dw #$0000
+    %cm_header("PHANTOON CONTROL")
+
+phan_fast_left:
+    %cm_toggle_bit("Fast Left", !ram_phantoon_rng_1, #$0020, 0)
+
+phan_mid_left:
+    %cm_toggle_bit(" Mid Left", !ram_phantoon_rng_1, #$0008, 0)
+
+phan_slow_left:
+    %cm_toggle_bit("Slow Left", !ram_phantoon_rng_1, #$0002, 0)
+
+phan_fast_right:
+    %cm_toggle_bit("Fast Right", !ram_phantoon_rng_1, #$0010, 0)
+
+phan_mid_right:
+    %cm_toggle_bit(" Mid Right", !ram_phantoon_rng_1, #$0004, 0)
+
+phan_slow_right:
+    %cm_toggle_bit("Slow Right", !ram_phantoon_rng_1, #$0001, 0)
+
+phan_eyeclose:
+    dw !ACTION_CHOICE
+    dl #!ram_phantoon_rng_3
+    dw #$0000
+    db #$28, "Phan Eye Close", #$FF
+    db #$28, "     RANDOM", #$FF
+    db #$28, "       SLOW", #$FF
+    db #$28, "        MID", #$FF
+    db #$28, "       FAST", #$FF
+    db #$FF
+
+phan_flamepattern:
+    dw !ACTION_CHOICE
+    dl #!ram_phantoon_rng_4
+    dw #$0000
+    db #$28, "Phan Flames   ", #$FF
+    db #$28, "     RANDOM", #$FF
+    db #$28, "      22222", #$FF
+    db #$28, "        111", #$FF
+    db #$28, "    3333333", #$FF
+    db #$28, "    1424212", #$FF
+    db #$FF
+
+phan_next_flamepattern:
+    dw !ACTION_CHOICE
+    dl #!ram_phantoon_rng_5
+    dw #$0000
+    db #$28, "Next Flames   ", #$FF
+    db #$28, "     RANDOM", #$FF
+    db #$28, "      22222", #$FF
+    db #$28, "        111", #$FF
+    db #$28, "    3333333", #$FF
+    db #$28, "    1424212", #$FF
+    db #$FF
 
 ; ----------
 ; Ctrl Menu

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -2167,6 +2167,7 @@ PhantoonMenu:
     dw #phan_eyeclose
     dw #phan_flamepattern
     dw #phan_next_flamepattern
+    dw #phan_skip_intro
     dw #$0000
     %cm_header("PHANTOON CONTROL")
 
@@ -2222,6 +2223,9 @@ phan_next_flamepattern:
     db #$28, "    3333333", #$FF
     db #$28, "    1424212", #$FF
     db #$FF
+
+phan_skip_intro:
+    %cm_toggle_bit("Skip Intro", !ram_phantoon_rng_2, #$0001, 0)
 
 ; ----------
 ; Ctrl Menu

--- a/src/rng.asm
+++ b/src/rng.asm
@@ -1,49 +1,23 @@
 ; Phantoon hijacks
 {
-    ; 1st pattern
-if !FEATURE_PAL
-    org $A7D5E9
-else
-    org $A7D5B5
-endif
-        ; $A7:D5B5 22 11 81 80 JSL $808111[$80:8111]
-        JSL hook_phantoon_1st_dir_rng
 
+    ; 1st pattern
 if !FEATURE_PAL
     org $A7D5DA
 else
     org $A7D5A6
 endif
-        ; $A7:D5A6 AD B6 05    LDA $05B6  [$7E:05B6] ; Frame counter
-        ; $A7:D5A9 4A          LSR A
-        JSL hook_phantoon_1st_pat
+        JSL hook_phantoon_1st_rng
+        rep $12 : NOP
 
     ; 2nd pattern
 if !FEATURE_PAL
-    org $A7D716
+    org $A7D0B0
 else
-    org $A7D6E2
+    org $A7D07C
 endif
-        ; $A7:D6E2 22 11 81 80 JSL $808111[$80:8111]
-        JSL hook_phantoon_2nd_dir_rng
-
-if !FEATURE_PAL
-    org $A7D0BF
-else
-    org $A7D08B
-endif
-        ; $A7:D08B AD B6 05    LDA $05B6  [$7E:05B6] ; Frame counter
-        ; $A7:D08E 89 01 00    BIT #$0001
-        JSL hook_phantoon_2nd_dir_2
-        NOP : NOP
-
-if !FEATURE_PAL
-    org $A7D0B0 ; hijack, RNG call for second pattern
-else
-    org $A7D07C ; hijack, RNG call for second pattern
-endif
-        ; $A7:D07C 22 11 81 80 JSL $808111[$80:8111]
-        JSL hook_phantoon_2nd_pat
+        JSL hook_phantoon_2nd_rng
+        rep $B : NOP
 
 if !FEATURE_PAL
     org $A7D098 ; Phantoon eye close timer
@@ -174,72 +148,170 @@ hook_beetom_set_rng:
     RTL
 }
 
-hook_phantoon_1st_dir_rng:
+
+    RTL
+
+
+; Table of Phantoon pattern durations & directions
+; bit 0 is direction, remaining bits are duration
+; Note that later entries in the table will tend to occur slightly more often.
+phan_pattern_table:
+    dw $003C<<1|1 ; fast left
+    dw $003C<<1|0 ; fast right
+    dw $0168<<1|1 ;  mid left
+    dw $0168<<1|0 ;  mid right
+    dw $02D0<<1|1 ; slow left
+    dw $02D0<<1|0 ; slow right
+
+
+; Patch to the following code, to determine Phantoon's first-round direction and pattern
+; $A7:D5A6 AD B6 05    LDA $05B6  [$7E:05B6]    ; Frame counter
+; $A7:D5A9 4A          LSR A
+; $A7:D5AA 29 03 00    AND #$0003
+; $A7:D5AD 0A          ASL A
+; $A7:D5AE A8          TAY
+; $A7:D5AF B9 53 CD    LDA $CD53,y[$A7:CD59]    ; Number of frames to figure-8
+; $A7:D5B2 8D E8 0F    STA $0FE8  [$7E:0FE8]
+; $A7:D5B5 22 11 81 80 JSL $808111[$80:8111]    ; RNG
+; $A7:D5B9 89 01 00    BIT #$0001               ; Sets Z for left pattern, !Z for right
+hook_phantoon_1st_rng:
 {
-    JSL $808111 ; Trying to preserve the number of RNG calls being done in the frame
+    LDA !ram_phantoon_rng_1
+    ; If set to all-on or all-off, don't mess with RNG.
+    BEQ .no_manip
+    CMP #$003F
+    BNE choose_phantoon_pattern
 
-    LDA !ram_phantoon_rng_1 : BEQ .no_manip
-    PHX : TAX : LDA.l phantoon_dirs,X : PLX : AND #$00FF
-    RTL
-
-  .no_manip
-    LDA $05E5
-    RTL
-}
-
-hook_phantoon_1st_pat:
-{
-    LDA !ram_phantoon_rng_1 : BEQ .no_manip
-    PHX : TAX : LDA.l phantoon_pats,X : PLX : AND #$00FF
-    RTL
-
-  .no_manip
-    LDA $05B6 : LSR A
-    RTL
-}
-
-hook_phantoon_2nd_dir_rng:
-{
-    JSL $808111 ; Trying to preserve the number of RNG calls being done in the frame
-
-    LDA !ram_phantoon_rng_2 : BEQ .no_manip
-
-    PHX : TAX : LDA.l phantoon_dirs,X : PLX : AND #$00FF
-    EOR #$0001
-    RTL
-
-  .no_manip
-    LDA $05E5
-    RTL
-}
-
-hook_phantoon_2nd_dir_2:
-{
-    LDA !ram_phantoon_rng_2 : BEQ .no_manip
-
-    ; I don't quite understand this part, but it works ¯\_(ツ)_/¯
-    LDA #$0001
+.no_manip:
+    LDA $05B6
+    LSR A
+    AND #$0003
+    ASL A
+    TAY
+    if !FEATURE_PAL
+        LDA $CD87,Y
+    else
+        LDA $CD53,Y
+    endif
+    STA $0FE8
+    JSL $808111
     BIT #$0001
     RTL
-
-  .no_manip
-    LDA $05B6 : BIT #$0001
-    RTL
 }
 
-hook_phantoon_2nd_pat:
+; Patch to the following code, to determine Phantoon's second-round direction and pattern
+; Also affects patterns during Phantoon's invisible phase
+; $A7:D07C 22 11 81 80 JSL $808111[$80:8111]
+; $A7:D080 29 07 00    AND #$0007
+; $A7:D083 0A          ASL A
+; $A7:D084 A8          TAY
+; $A7:D085 B9 53 CD    LDA $CD53,y[$A7:CD5B]
+; $A7:D088 8D E8 0F    STA $0FE8  [$7E:0FE8]
+; $A7:D08B AD B6 05    LDA $05B6  [$7E:05B6]
+; $A7:D08E 89 01 00    BIT #$0001
+hook_phantoon_2nd_rng:
 {
-    JSL $808111 ; Trying to preserve the number of RNG calls being done in the frame
+    LDA !ram_phantoon_rng_1
+    ; If set to all-on or all-off, don't mess with RNG.
+    BEQ .no_manip
+    CMP #$003F
+    BNE choose_phantoon_pattern
 
-    LDA !ram_phantoon_rng_2 : BEQ .no_manip
-
-    PHX : TAX : LDA.l phantoon_pats,X : PLX : AND #$00FF
-    RTL
-
-  .no_manip
-    LDA $05E5
+.no_manip:
+    JSL $808111
+    AND #$0007
+    ASL A
+    TAY
+    if !FEATURE_PAL
+        LDA $CD87,Y
+    else
+        LDA $CD53,Y
+    endif
+    STA $0FE8
+    LDA $05B6
+    BIT #$0001
     RTL
 }
+
+choose_phantoon_pattern:
+{
+    ; get random number in range 0-7
+    JSL $808111
+    AND #$0007
+
+    PHX
+    TAX
+    ; play a game of eeny-meeny-miny-moe with the enabled patterns
+    ; X = number of enabled patterns to find before stopping
+    ; Y = index in phan_pattern_table of pattern currently being checked
+    ; A = bitmask of enabled patterns
+.reload:
+    LDY #$0006  ; number of patterns (decremented immediately to index of last pattern)
+    LDA !ram_phantoon_rng_1
+.loop:
+    DEY
+    LSR
+    BCC .skip
+
+    ; Pattern index Y is enabled
+    DEX         ; is this the last one?
+    BMI .done
+    BRA .loop   ; no, keep looping
+
+.skip:
+    ; Pattern Y is not enabled, try the next pattern
+    BEQ .reload ; if we've tried all the patterns, start over
+    BRA .loop
+
+.done:
+
+    ; We've found the pattern to use.
+    TYA : ASL : TAX
+    LDA.l phan_pattern_table,X
+    PLX
+
+    ; Check if Phantoon is in the round 2 AI state
+    LDY $0fb2
+    if !FEATURE_PAL
+        CPY #$D716
+    else
+        CPY #$D6E2
+    endif
+    beq .round2
+
+    ; If not, save the pattern timer and return the direction in the zero flag.
+    LSR         ; shift direction into carry
+    STA $0FE8
+
+    LDA #$0000
+    ROL         ; shift carry into A (and zero flag)
+    RTL
+
+.round2:
+    ; Save the pattern timer, check the direction, and
+    ; set Phantoon's starting point and pattern index.
+    LSR
+    STA $0FE8
+    BCS .left
+
+    ; Right pattern
+    LDA #$0088
+    LDY #$00D0
+    BRA .round2done
+
+.left:
+    LDA #$018F
+    LDY #$0030
+
+.round2done:
+    STA $0FA8  ; Index into figure-8 movement table
+    STY $0F7A  ; X position
+    LDA #$0060
+    STA $0F7E  ; Y position
+
+    RTL
+}
+
 
 hook_phantoon_eyeclose:
 {

--- a/web/data/help.mdx
+++ b/web/data/help.mdx
@@ -139,11 +139,11 @@
 |&nbsp;|
 | **RNG Control**               | Pre-determine boss patterns
 | - Rerandomize                 | Toggles rerandomizing of RNG values upon loading a savestate. SD2SNES/FXPak versions only.
-| - Phan 1st Phase              | Choose the direction and eye opening pattern for Phantoon's first phase
-| - Phan 2nd Phase              | Choose the direction and eye opening pattern for Phantoon's second and subsequent phases
-| - Phan Eye Close              | Choose how long Phantoon's eye will remain open after a ring of flames
-| - Phan Flame Pattern          | Choose one of four patterns for Phantoon's flames
-| - Next Flame Pattern          | Swaps with Phan Flame Pattern each time Phantoon chooses a pattern
+| - Phantoon                    | Configure possible Phantoon patterns. You can enable or disable individual patterns per-round, allowing you to practice only a subset of possible patterns. The round-1 toggles apply only to the first round, whereas the round-2 toggles apply to all subsequent rounds, including rounds where Phantoon is invisible.
+|                               | If all patterns are enabled (or disabled) for a round, vanilla RNG is used with all its quirks and biases. However, if you customize the patterns for a round, that round will use a customized RNG that chooses patterns with mostly-balanced probabilities (though slower patterns may still tend to be slightly more common).
+|                               | - Phan Eye Close: Choose how long Phantoon's eye will remain open after a ring of flames
+|                               | - Phan Flame Pattern: Choose one of four patterns for Phantoon's flames
+|                               | - Next Flame Pattern: Swaps with Phan Flame Pattern each time Phantoon chooses a pattern
 | - Botwoon RNG                 | Choose the opening pattern for Botwoon's first cycle
 | - Draygon from Right          | Choose Draygon's attack type from the right side of the room. Draygon will always 'swoop' after a 'goop'.
 | - Draygon from Left           | Choose Draygon's attack type from the left side of the room. Draygon will always 'swoop' after a 'goop'.


### PR DESCRIPTION
As specified in #62, allow the user to select a subset of Phantoon patterns to practice.

Implemented using hooks in Phantoon's AI that override the default RNG-based pattern chooser with a custom implementation that chooses patterns from the user-selected subset. If all the patterns are enabled (or all are disabled), the custom logic is disabled and Phantoon's regular RNG code is run instead -- so this feature should not impact
Phantoon's behavior or pattern probabilities when not in use.

Also includes an option to skip the long intro, because I got tired of sitting through it. With the "Skip Intro" option enabled, Phantoon begins the fight (starting from his wavy-fade-in animation) immediately when you enter the boss room.