### PR TITLE
Last realtime door

### DIFF
--- a/src/defines.asm
+++ b/src/defines.asm
@@ -15,7 +15,7 @@
 !ram_last_door_lag_frames = !WRAM_START+$0C
 !ram_transition_counter = !WRAM_START+$0E
 !ram_transition_flag = !WRAM_START+$10
-!ram_transition_flag_2 = !WRAM_START+$12
+!ram_last_realtime_door = !WRAM_START+$12
 
 !ram_seg_rt_frames = !WRAM_START+$14
 !ram_seg_rt_seconds = !WRAM_START+$16

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -293,6 +293,7 @@ ih_after_room_transition:
     LDA !ram_transition_counter : STA !ram_last_door_lag_frames
     LDA !sram_lag_counter_mode : BEQ .done_set_door_lag
     LDA !ram_realtime_room : STA !ram_last_door_lag_frames
+    LDA !ram_realtime_room : STA !ram_last_realtime_door
   .done_set_door_lag
     LDA #$0000 : STA !ram_transition_flag
 
@@ -348,6 +349,7 @@ ih_before_room_transition:
     ; Realtime
     LDA !ram_realtime_room : STA !ram_last_realtime_room
     LDA #$0000 : STA !ram_realtime_room
+    LDA #$0000 : STA !ram_last_realtime_door
 
     ; Save temp variables
     LDA $12 : PHA

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -572,8 +572,7 @@ endif
     LDA !sram_display_mode : CMP #!IH_MODE_SHINETUNE_INDEX : BEQ .end
 
     ; Door lag
-    LDA !ram_last_door_lag_frames : LDX #$00C2 : JSR Draw3
-    BRA .pick_segment_timer
+    BRA .vanilla_infohud_draw_door_lag
 
   .vanilla_infohud_draw_lag_and_reserves
     LDA !SAMUS_RESERVE_MODE : CMP #$0001 : BNE .vanilla_infohud_draw_lag
@@ -591,6 +590,7 @@ endif
     ; Skip door lag and segment timer when shinetune enabled
     LDA !sram_display_mode : CMP #!IH_MODE_SHINETUNE_INDEX : BEQ .end
 
+  .vanilla_infohud_draw_door_lag
     ; Door lag
     LDA !ram_last_door_lag_frames : LDX #$00C2 : JSR Draw2
 


### PR DESCRIPTION
This change adds a new variable `ram_last_realtime_door` which holds the full door transition time and not just the door "lag" time.  The variable replaces `ram_transition_flag_2`, which was unused.

I am using this in my room and segment timer (https://github.com/cout/sm_room_timer) to accurately measure full room time.  The full transition time is needed so the individual room times can meaningfully be added together to create a realistic estimate of RTA time in a real speedrun.  Replacing `ram_transition_flag_2` instead of adding the variable further down in memory ensures I can easily scrape the variable along with the other room time variables when the transition completes.

This also modifies the full transition lag counter in the infohud to use the new variable (the previous code stored the full transition time in `ram_last_door_lag_frames` when "Transition Lag" was set to "FULL").  This ensures I can still scrape door lag time regardless of what "Transition Lag" is set to.