### PR TITLE
Avoid accidental pauses from controller shortcuts

### DIFF
--- a/src/gamemode.asm
+++ b/src/gamemode.asm
@@ -259,6 +259,8 @@ endif
     LDA $AB : PHA
     LDA #$0004 : STA $AB
 
+    JSR skip_pause
+
     ; Enter MainMenu
     JSL cm_start
 
@@ -266,7 +268,7 @@ endif
     PLA : STA $AB
 
     ; SEC to skip normal gameplay for one frame after handling the menu
-    SEC : JMP skip_pause
+    SEC : RTS
 }
 
 if !FEATURE_SD2SNES

--- a/src/gamemode.asm
+++ b/src/gamemode.asm
@@ -40,6 +40,30 @@ gamemode_start:
     RTL
 }
 
+; If the current game mode is $C (fading out to pause), set it to $8 (normal), so that
+;  shortcuts involving the start button don't trigger accidental pauses.
+; Called after handling most controller shortcuts, except save/load state (because the 
+;  user might want to practice gravity jumps or something) and load preset (because
+;  presets reset the game mode anyway).
+skip_pause:
+{
+    PHP ; preserve carry
+    LDA !GAMEMODE
+    CMP #$000C
+    BNE .done
+    LDA #$0008
+    STA !GAMEMODE
+    LDA #$0001
+    STZ $0723   ; Screen fade delay = 0
+    STZ $0725   ; Screen fade counter = 0
+    LDA $0051
+    ORA #$000F
+    STA $0051   ; Brightness = $F (max)
+.done:
+    PLP
+    RTS
+}
+
 gamemode_shortcuts:
 {
     LDA !IH_CONTROLLER_PRI_NEW : BNE +
@@ -134,7 +158,7 @@ endif
   .kill_enemies
     JSL kill_enemies
     ; CLC to continue normal gameplay after killing enemies
-    CLC : RTS
+    CLC : JMP skip_pause
 
   .load_last_preset
     LDA !sram_last_preset : BEQ + : STA !ram_load_preset
@@ -147,12 +171,12 @@ endif
     LDA #$0000 : STA !ram_seg_rt_frames
     STA !ram_seg_rt_seconds : STA !ram_seg_rt_minutes
     ; CLC to continue normal gameplay after resetting segment timer
-    CLC : RTS
+    CLC : JMP skip_pause
 
   .reset_segment_later
     LDA #$7FFF : STA !ram_reset_segment_later
     ; CLC to continue normal gameplay after setting segement timer reset
-    CLC : RTS
+    CLC : JMP skip_pause
 
   .full_equipment
     LDA $7E09C4 : STA $7E09C2 ; health
@@ -161,19 +185,19 @@ endif
     LDA $7E09D0 : STA $7E09CE ; pbs
     LDA $7E09D4 : STA $7E09D6 ; reserves
     ; CLC to continue normal gameplay after equipment refill
-    CLC : RTS
+    CLC : JMP skip_pause
 
   .toggle_tileviewer
     LDA !ram_oob_watch_active : BEQ .turnOnTileViewer
     LDA #$0000 : STA !ram_oob_watch_active : STA !ram_sprite_features_active
     ; CLC to continue normal gameplay after disabling OOB Tile Viewer
-    CLC : RTS
+    CLC : JMP skip_pause
 
   .turnOnTileViewer
     LDA #$0001 : STA !ram_oob_watch_active : STA !ram_sprite_features_active
     JSL upload_sprite_oob_tiles
     ; CLC to continue normal gameplay after enabling OOB Tile Viewer
-    CLC : RTS
+    CLC : JMP skip_pause
 
   .random_preset
     JSL LoadRandomPreset
@@ -190,7 +214,7 @@ endif
     JSL custom_preset_save
     ; CLC to continue normal gameplay after saving preset
     LDA #!SOUND_MENU_JSR : JSL !SFX_LIB1
-    CLC : RTS
+    CLC : JMP skip_pause
 
   .load_custom_preset
     ; check if slot is populated first
@@ -201,7 +225,7 @@ endif
   .not_safe
     LDA #!SOUND_MENU_FAIL : JSL !SFX_LIB1
     ; CLC to continue normal gameplay after failing to save or load preset
-    CLC : RTS
+    CLC : JMP skip_pause
 
   .load_safe
     STA !ram_custom_preset
@@ -215,7 +239,7 @@ endif
 +   INC : STA !sram_custom_preset_slot
     ASL : TAX : LDA.l NumberGFXTable,X : STA $7EC67C
     ; CLC to continue normal gameplay after incrementing preset slot
-    CLC : RTS
+    CLC : JMP skip_pause
 
   .prev_preset_slot
     LDA !sram_custom_preset_slot : BNE +
@@ -223,12 +247,12 @@ endif
 +   DEC : STA !sram_custom_preset_slot
     ASL : TAX : LDA.l NumberGFXTable,X : STA $7EC67C
     ; CLC to continue normal gameplay after decrementing preset slot
-    CLC : RTS
+    CLC : JMP skip_pause
 
   .update_timers
     JSL ih_update_hud_early
     ; CLC to continue normal gameplay after updating HUD timers
-    CLC : RTS
+    CLC : JMP skip_pause
 
   .menu
     ; Set IRQ vector
@@ -242,7 +266,7 @@ endif
     PLA : STA $AB
 
     ; SEC to skip normal gameplay for one frame after handling the menu
-    SEC : RTS
+    SEC : JMP skip_pause
 }
 
 if !FEATURE_SD2SNES


### PR DESCRIPTION
As recently discussed in Discord, controller shortcuts involving the start button (most commonly the Start+Select menu shortcut) will cause the game to pause unless start is the last input pressed. In order to avoid this, check if the game is in the "fading out to pause" mode after handling most shortcuts. If so, cancel the pause by returning to the "normal gameplay" mode and resetting the screen brightness.

This behavior applies to all controller shortcuts except loading presets (because presets reset the game mode anyway) and saving/loading savestates (because the user might actually want to savestate in the middle of a pause, for instance to practice a gravity jump).

I don't *think* there's any way this could break anything, since the only thing it does is abort the fade animation. It should always be safe to set brightness to 15 since the unpause animation always sets it to the max; and I can't think of any scenario where the user should not be able to break out of a pause animation. But this game has surprised me before, so it's definitely possible I missed something.