### PR TITLE
Fix music after teleporting/loading a save

### DIFF
--- a/src/misc.asm
+++ b/src/misc.asm
@@ -198,7 +198,9 @@ org $90E874
 else
 org $90E877
 endif
-    BRA $1F
+    LDA $07F5
+    JSL $808FC1 ; queue room music track
+    BRA $18
 
 
 ; Adds frames when unpausing (nmi is turned off during vram transfers)


### PR DESCRIPTION
When we skip the start-game fanfare, we also skip starting the room music at the end of the fanfare. So add the room music back in, in place of the fanfare.