### PR TITLE
Reduce custom preset size so we can have more

### DIFF
--- a/src/custompresets.asm
+++ b/src/custompresets.asm
@@ -5,10 +5,194 @@
 org $83B400
 print pc, " custompresets start"
 
+if !FEATURE_TINYSTATES
 custom_preset_save:
 {
     LDA !sram_custom_preset_slot
-    ASL : XBA : TAX ; multiply by 200h (slot offset)
+    XBA : TAX                    ; multiply by 100h (slot offset)
+    LDA #$5AFE : STA $703000,X   ; mark this slot as "SAFE" to load
+    LDA #$00BE : STA $703002,X   ; record slot size for future compatibility
+    LDA $078D : STA $703004,X    ; DDB
+    LDA $079B : STA $703006,X    ; MDB
+    LDA $07F3 : STA $703008,X    ; Music Bank
+    LDA $07F5 : STA $70300A,X    ; Music Track
+    LDA $090F : STA $70300C,X    ; Screen subpixel X position
+    LDA $0911 : STA $70300E,X    ; Screen X position in pixels
+    LDA $0913 : STA $703010,X    ; Screen subpixel Y position
+    LDA $0915 : STA $703012,X    ; Screen Y position in pixels
+    LDA $0917 : STA $703014,X    ; Layer 2 X position
+    LDA $0919 : STA $703016,X    ; Layer 2 Y position
+    LDA $0921 : STA $703018,X    ; BG2 X offset
+    LDA $0923 : STA $70301A,X    ; BG2 Y offset
+    LDA $093F : STA $70301C,X    ; Ceres escape flag
+    LDA $09A2 : STA $70301E,X    ; Equipped Items
+    LDA $09A4 : STA $703020,X    ; Collected Items
+    LDA $09A6 : STA $703022,X    ; Beams
+    LDA $09A8 : STA $703024,X    ; Beams
+    LDA $09C0 : STA $703026,X    ; Manual/Auto reserve tank
+    LDA $09C2 : STA $703028,X    ; Health
+    LDA $09C4 : STA $70302A,X    ; Max health
+    LDA $09C6 : STA $70302C,X    ; Missiles
+    LDA $09C8 : STA $70302E,X    ; Max missiles
+    LDA $09CA : STA $703030,X    ; Supers
+    LDA $09CC : STA $703032,X    ; Max supers
+    LDA $09CE : STA $703034,X    ; Pbs
+    LDA $09D0 : STA $703036,X    ; Max pbs
+    LDA $09D2 : STA $703038,X    ; Currently selected item
+    LDA $09D4 : STA $70303A,X    ; Max reserves
+    LDA $09D6 : STA $70303C,X    ; Reserves
+    LDA $0A1C : STA $70303E,X    ; Samus position/state
+    LDA $0A1E : STA $703040,X    ; More position/state
+    LDA $0A68 : STA $703042,X    ; Flash suit
+    LDA $0A76 : STA $703044,X    ; Hyper beam
+    LDA $0AF6 : STA $703046,X    ; Samus X
+    LDA $0AF8 : STA $703048,X    ; Samus subpixel X
+    LDA $0AFA : STA $70304A,X    ; Samus Y
+    LDA $0AFC : STA $70304C,X    ; Samus subpixel Y
+    LDA $0B3F : STA $70304E,X    ; Blue suit
+    LDA $7ED820 : STA $703050,X  ; Events
+    LDA $7ED822 : STA $703052,X  ; Events
+    LDA $7ED828 : STA $703054,X  ; Bosses
+    LDA $7ED82A : STA $703056,X  ; Bosses
+    LDA $7ED82C : STA $703058,X  ; Bosses
+    LDA $7ED82E : STA $70305A,X  ; Bosses
+    LDA $7ED870 : STA $70305C,X  ; Items
+    LDA $7ED872 : STA $70305E,X  ; Items
+    LDA $7ED874 : STA $703060,X  ; Items
+    LDA $7ED876 : STA $703062,X  ; Items
+    LDA $7ED878 : STA $703064,X  ; Items
+    LDA $7ED87A : STA $703066,X  ; Items
+    LDA $7ED87C : STA $703068,X  ; Items
+    LDA $7ED87E : STA $70306A,X  ; Items
+    LDA $7ED880 : STA $70306C,X  ; Items
+    LDA $7ED882 : STA $70306E,X  ; Items
+    LDA $7ED8B0 : STA $703070,X  ; Doors
+    LDA $7ED8B2 : STA $703072,X  ; Doors
+    LDA $7ED8B4 : STA $703074,X  ; Doors
+    LDA $7ED8B6 : STA $703076,X  ; Doors
+    LDA $7ED8B8 : STA $703078,X  ; Doors
+    LDA $7ED8BA : STA $70307A,X  ; Doors
+    LDA $7ED8BC : STA $70307C,X  ; Doors
+    LDA $7ED8BE : STA $70307E,X  ; Doors
+    LDA $7ED8C0 : STA $703080,X  ; Doors
+    LDA $7ED8C2 : STA $703082,X  ; Doors
+    LDA $7ED8C4 : STA $703084,X  ; Doors
+    LDA $7ED908 : STA $703086,X  ; Map Stations
+    LDA $7ED90A : STA $703088,X  ; Map Stations
+    LDA $7ED90C : STA $70308A,X  ; Map Stations
+    LDA $7ECD20 : STA $70308C,X  ; Scrolls
+    LDA $7ECD22 : STA $70308E,X  ; Scrolls
+    LDA $7ECD24 : STA $703090,X  ; Scrolls
+    LDA $7ECD26 : STA $703092,X  ; Scrolls
+    LDA $7ECD28 : STA $703094,X  ; Scrolls
+    LDA $7ECD2A : STA $703096,X  ; Scrolls
+    LDA $7ECD2C : STA $703098,X  ; Scrolls
+    LDA $7ECD2E : STA $70309A,X  ; Scrolls
+    LDA $7ECD30 : STA $70309C,X  ; Scrolls
+    LDA $7ECD32 : STA $70309E,X  ; Scrolls
+    LDA $7ECD34 : STA $7030A0,X  ; Scrolls
+    LDA $7ECD36 : STA $7030A2,X  ; Scrolls
+    LDA $7ECD38 : STA $7030A4,X  ; Scrolls
+    LDA $7ECD3A : STA $7030A6,X  ; Scrolls
+    LDA $7ECD3C : STA $7030A8,X  ; Scrolls
+    LDA $7ECD3E : STA $7030AA,X  ; Scrolls
+    LDA $7ECD40 : STA $7030AC,X  ; Scrolls
+    LDA $7ECD42 : STA $7030AE,X  ; Scrolls
+    LDA $7ECD44 : STA $7030B0,X  ; Scrolls
+    LDA $7ECD46 : STA $7030B2,X  ; Scrolls
+    LDA $7ECD48 : STA $7030B4,X  ; Scrolls
+    LDA $7ECD4A : STA $7030B6,X  ; Scrolls
+    LDA $7ECD4C : STA $7030B8,X  ; Scrolls
+    LDA $7ECD4E : STA $7030BA,X  ; Scrolls
+    LDA $7ECD50 : STA $7030BC,X  ; Scrolls
+    ; next available byte is $7030BE
+    RTL
+}
+
+custom_preset_load:
+{
+    LDA !sram_custom_preset_slot
+    XBA : TAX                    ; multiply by 100h (slot offset)
+                                 ; skip past "5AFE" word
+                                 ; skip past size for now
+    LDA $703004,X : STA $078D    ; DDB
+    LDA $703006,X : STA $079B    ; MDB
+    LDA $703008,X : STA $07F3    ; Music Bank
+    LDA $70300A,X : STA $07F5    ; Music Track
+    LDA $70300C,X : STA $090F    ; Screen subpixel X position
+    LDA $70300E,X : STA $0911    ; Screen X position in pixels
+    LDA $703010,X : STA $0913    ; Screen subpixel Y position
+    LDA $703012,X : STA $0915    ; Screen Y position in pixels
+    LDA $703014,X : STA $0917    ; Layer 2 X position
+    LDA $703016,X : STA $0919    ; Layer 2 Y position
+    LDA $703018,X : STA $0921    ; BG2 X offset
+    LDA $70301A,X : STA $0923    ; BG2 Y offset
+    LDA $70301C,X : STA $093F    ; Ceres escape flag
+    LDA $70301E,X : STA $09A2    ; Equipped Items
+    LDA $703020,X : STA $09A4    ; Collected Items
+    LDA $703022,X : STA $09A6    ; Beams
+    LDA $703024,X : STA $09A8    ; Beams
+    LDA $703026,X : STA $09C0    ; Manual/Auto reserve tank
+    LDA $703028,X : STA $09C2    ; Health
+    LDA $70302A,X : STA $09C4    ; Max health
+    LDA $70302C,X : STA $09C6    ; Missiles
+    LDA $70302E,X : STA $09C8    ; Max missiles
+    LDA $703030,X : STA $09CA    ; Supers
+    LDA $703032,X : STA $09CC    ; Max supers
+    LDA $703034,X : STA $09CE    ; Pbs
+    LDA $703036,X : STA $09D0    ; Max pbs
+    LDA $703038,X : STA $09D2    ; Currently selected item
+    LDA $70303A,X : STA $09D4    ; Max reserves
+    LDA $70303C,X : STA $09D6    ; Reserves
+    LDA $70303E,X : STA $0A1C    ; Samus position/state
+    LDA $703040,X : STA $0A1E    ; More position/state
+    LDA $703042,X : STA $0A68    ; Flash suit
+    LDA $703044,X : STA $0A76    ; Hyper beam
+    LDA $703046,X : STA $0AF6    ; Samus X
+    LDA $703048,X : STA $0AF8    ; Samus subpixel X
+    LDA $70304A,X : STA $0AFA    ; Samus Y
+    LDA $70304C,X : STA $0AFC    ; Samus subpixel Y
+    LDA $70304E,X : STA $0B3F    ; Blue suit
+    LDA $703050,X : STA $7ED820  ; Events
+    LDA $703052,X : STA $7ED822  ; Events
+    LDA $703054,X : STA $7ED828  ; Bosses
+    LDA $703056,X : STA $7ED82A  ; Bosses
+    LDA $703058,X : STA $7ED82C  ; Bosses
+    LDA $70305A,X : STA $7ED82E  ; Bosses
+    LDA $70305C,X : STA $7ED870  ; Items
+    LDA $70305E,X : STA $7ED872  ; Items
+    LDA $703060,X : STA $7ED874  ; Items
+    LDA $703062,X : STA $7ED876  ; Items
+    LDA $703064,X : STA $7ED878  ; Items
+    LDA $703066,X : STA $7ED87A  ; Items
+    LDA $703068,X : STA $7ED87C  ; Items
+    LDA $70306A,X : STA $7ED87E  ; Items
+    LDA $70306C,X : STA $7ED880  ; Items
+    LDA $70306E,X : STA $7ED882  ; Items
+    LDA $703070,X : STA $7ED8B0  ; Doors
+    LDA $703072,X : STA $7ED8B2  ; Doors
+    LDA $703074,X : STA $7ED8B4  ; Doors
+    LDA $703076,X : STA $7ED8B6  ; Doors
+    LDA $703078,X : STA $7ED8B8  ; Doors
+    LDA $70307A,X : STA $7ED8BA  ; Doors
+    LDA $70307C,X : STA $7ED8BC  ; Doors
+    LDA $70307E,X : STA $7ED8BE  ; Doors
+    LDA $703080,X : STA $7ED8C0  ; Doors
+    LDA $703082,X : STA $7ED8C2  ; Doors
+    LDA $703084,X : STA $7ED8C4  ; Doors
+    LDA $703086,X : STA $7ED908  ; Map Stations
+    LDA $703088,X : STA $7ED90A  ; Map Stations
+    LDA $70308A,X : STA $7ED90C  ; Map Stations
+    ; set flag to load scrolls later
+    LDA #$5AFE : STA !ram_custom_preset
+    ; next available byte is $7030BE
+    RTL
+}
+else
+custom_preset_save:
+{
+    LDA !sram_custom_preset_slot
+    ASL : XBA : TAX              ; multiply by 200h (slot offset)
     LDA #$5AFE : STA $703000,X   ; mark this slot as "SAFE" to load
     LDA #$01EE : STA $703002,X   ; record slot size for future compatibility
     LDA $078B : STA $703004,X    ; Elevator Index
@@ -168,6 +352,7 @@ custom_preset_load:
     LDA #$0000 : STA !ram_custom_preset
     RTL
 }
+endif
 
 preset_scroll_fixes:
 {
@@ -453,8 +638,13 @@ preset_scroll_fixes:
 
   .custom_presets
     LDA !sram_custom_preset_slot
-    ASL : XBA
+if !FEATURE_TINYSTATES
+    XBA                          ; multiply by 100h (slot offset)
+    CLC : ADC #$30BD : TAX       ; X = Source
+else
+    ASL : XBA                    ; multiply by 200h (slot offset)
     CLC : ADC #$31E9 : TAX       ; X = Source
+endif
     LDY #$CD51 : LDA #$0031      ; Y = Destination, A = Size-1
     MVP $707E                    ; srcBank, destBank
     TDC : STA !ram_custom_preset

--- a/src/gamemode.asm
+++ b/src/gamemode.asm
@@ -220,7 +220,11 @@ endif
   .load_custom_preset
     ; check if slot is populated first
     LDA !sram_custom_preset_slot
-    ASL : XBA : TAX
+if !FEATURE_TINYSTATES
+    XBA : TAX                    ; multiply by 100h (slot offset)
+else
+    ASL : XBA : TAX              ; multiply by 200h (slot offset)
+endif
     LDA $703000,X : CMP #$5AFE : BEQ .load_safe
 
   .not_safe
@@ -235,11 +239,11 @@ endif
     SEC : RTS
 
   .next_preset_slot
-    if !FEATURE_TINYSTATES
-      LDA !sram_custom_preset_slot : CMP #$0007 ; total slots minus one
-    else
-      LDA !sram_custom_preset_slot : CMP #$0027 ; total slots minus one
-    endif
+if !FEATURE_TINYSTATES
+    LDA !sram_custom_preset_slot : CMP #$000F ; total slots minus one
+else
+    LDA !sram_custom_preset_slot : CMP #$0027 ; total slots minus one
+endif
     BNE + : LDA #$FFFF
 +   INC : STA !sram_custom_preset_slot
     ASL : TAX : LDA.l NumberGFXTable,X : STA $7EC67C
@@ -248,11 +252,11 @@ endif
 
   .prev_preset_slot
     LDA !sram_custom_preset_slot : BNE +
-    if !FEATURE_TINYSTATES
-      LDA #$0008 ; total slots
-    else
-      LDA #$0028 ; total slots
-    endif
+if !FEATURE_TINYSTATES
+    LDA #$0010 ; total slots
+else
+    LDA #$0028 ; total slots
+endif
 +   DEC : STA !sram_custom_preset_slot
     ASL : TAX : LDA.l NumberGFXTable,X : STA $7EC67C
     ; CLC to continue normal gameplay after decrementing preset slot

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -330,7 +330,7 @@ presets_goto_select_preset_category:
 
 presets_custom_preset_slot:
 if !FEATURE_TINYSTATES
-    %cm_numfield("Custom Preset Slot", !sram_custom_preset_slot, 0, 7, 1, 2, #0) ; update total slots in gamemode.asm
+    %cm_numfield("Custom Preset Slot", !sram_custom_preset_slot, 0, 15, 1, 2, #0) ; update total slots in gamemode.asm
 else
     %cm_numfield("Custom Preset Slot", !sram_custom_preset_slot, 0, 39, 1, 2, #0) ; update total slots in gamemode.asm
 endif
@@ -487,7 +487,11 @@ action_load_custom_preset:
 {
     ; check if slot is populated first
     LDA !sram_custom_preset_slot
-    ASL : XBA : TAX
+if !FEATURE_TINYSTATES
+    XBA : TAX                    ; multiply by 100h (slot offset)
+else
+    ASL : XBA : TAX              ; multiply by 200h (slot offset)
+endif
     LDA $703000,X : CMP #$5AFE : BEQ .safe
     LDA #!SOUND_MENU_FAIL : JSL !SFX_LIB1
     RTL

--- a/src/tinystates.asm
+++ b/src/tinystates.asm
@@ -56,7 +56,6 @@ pre_load_state:
     RTS
 }
 
-print pc
 post_load_state:
 {
     JSL stop_all_sounds


### PR DESCRIPTION
Custom presets were based on the original presets, but later on we realized the original presets had a lot of useless information.  We chose not to break backwards compatibility with existing custom presets.

With new 128k SRAM layout, it is a good time to redo custom presets so they take half the space and we can support 16 custom presets.

They actually take up less than 192 bytes, so if you really wanted you could redo logic to support 21 custom presets, but you'd have no room for future expansion... although the custom presets seem pretty good now, not sure if we would need to change them again.