### PR TITLE
Preserve Zebes Escape Timer

### DIFF
--- a/src/misc.asm
+++ b/src/misc.asm
@@ -249,6 +249,15 @@ org $808F65
     JML hook_set_music_data
 
 
+; Continue drawing escape timer after reaching ship
+org $90E908
+    JSR preserve_escape_timer
+
+; Stop drawing timer when its VRAM is overwritten
+org $A2ABFD
+    JML clear_escape_timer
+
+
 org $90F800
 print pc, " misc bank90 start"
 
@@ -570,6 +579,28 @@ spacetime_routine:
     RTS
 }
 endif
+
+
+preserve_escape_timer:
+{
+    ; check if timer is active
+    LDA $0943 : AND #$0006 : BEQ .done
+    JSL $809F6C ; Draw timer
+
+  .done
+    JMP $EA7F ; overwritten code
+}
+
+clear_escape_timer:
+{
+    ; clear timer status
+    STZ $0943
+
+    ; overwritten code
+    LDA #$AC1B : STA $0FB2,X
+    STZ $0DEC
+    RTL
+}
 
 print pc, " misc bank90 end"
 


### PR DESCRIPTION
The Zebes Escape timer will instantly disappear when Samus faces forward on the ship, making it difficult to see the final time.

The first hijack is at [$90E908](https://patrickjohnston.org/bank/90#fE902) which is run when $0A44 is set to "entering/exiting gunship". It continues running the "draw timer" routine as long as $0943 (timer status) is non-zero. The second hijack at [$A2ABFD](https://patrickjohnston.org/bank/A2#fABC7) runs when the timer graphics are set to be overwritten in VRAM. It clears timer status to prevent garbage graphics from being drawn.