### PR TITLE
Fix Golden Torizo drops

### DIFF
--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -121,7 +121,7 @@ endif
 if !FEATURE_PAL
 org $A0BB16      ; update timers when Golden Torizo drops spawn
 else
-org $A0BB04      ; update timers when Golden Torizo drops spawn
+org $A0BB06      ; update timers when Golden Torizo drops spawn
 endif
     JML ih_drops_segment
 


### PR DESCRIPTION
The address was off by two bytes, overwriting the branch instruction and breaking the drop spawning loop.
https://patrickjohnston.org/bank/A0?just=BAD7