### PR TITLE
Misc 2.5.1 things

### DIFF
--- a/src/crash.asm
+++ b/src/crash.asm
@@ -348,7 +348,7 @@ CrashDump:
     ; -- Draw header --
     LDA.l #CrashTextHeader : STA !ram_crash_text
     LDA.l #CrashTextHeader>>16 : STA !ram_crash_text_bank
-    LDX #$0086 : JSR crash_draw_text
+    LDX #$008C : JSR crash_draw_text
 
     ; -- Draw footer message --
     LDA.l #CrashTextFooter1 : STA !ram_crash_text
@@ -1023,7 +1023,15 @@ crash_read_inputs:
 
 CrashTextHeader:
     table ../resources/header.tbl
-    db "SM SHOT ITSELF IN THE FOOT", #$FF
+if !VERSION_REV_1
+    db "CRASH HANDLER ", "!VERSION_MAJOR", ".", "!VERSION_MINOR", ".", "!VERSION_BUILD", ".", "!VERSION_REV_1", "!VERSION_REV_2", #$FF
+else
+if !VERSION_REV_2
+    db "CRASH HANDLER ", "!VERSION_MAJOR", ".", "!VERSION_MINOR", ".", "!VERSION_BUILD", ".", "!VERSION_REV_2", #$FF
+else
+    db "CRASH HANDLER ", "!VERSION_MAJOR", ".", "!VERSION_MINOR", ".", "!VERSION_BUILD", #$FF
+endif
+endif
     table ../resources/normal.tbl
 
 CrashTextFooter1:

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -39,6 +39,9 @@ org $809B4C      ; hijack, HUD routine (game timer by Quote58)
 org $8290F6      ; hijack, HUD routine while paused
     JSL ih_hud_code_paused
 
+org $80A16B      ; hijack, adjust room times and update HUD when unpausing
+    JSL ih_unpause
+
 org $82894F      ; hijack, main game loop: runs EVERY frame (used for room transition timer)
     JSL ih_game_loop_code
 
@@ -389,6 +392,30 @@ ceres_start_timers:
     STZ $0725
     
     JML ceres_start_timers_return
+}
+
+ih_unpause:
+; Adds frames when unpausing (nmi is turned off during vram transfers)
+{
+    ; RT room
+    LDA !ram_realtime_room : CLC : ADC.w #41 : STA !ram_realtime_room
+
+    ; RT seg
+    LDA !ram_seg_rt_frames : CLC : ADC.w #41 : STA !ram_seg_rt_frames
+    CMP.w #60 : BCC .updateHUD
+    SEC : SBC.w #60 : STA !ram_seg_rt_frames
+
+    LDA !ram_seg_rt_seconds : INC : STA !ram_seg_rt_seconds
+    CMP.w #60 : BCC .updateHUD
+    LDA #$0000 : STA !ram_seg_rt_seconds
+
+    LDA !ram_seg_rt_minutes : INC : STA !ram_seg_rt_minutes
+
+  .updateHUD
+    JSL ih_update_hud_early
+
+    ; Replace overwritten logic to enable NMI
+    JML $80834B
 }
 
 ih_elevator_activation:

--- a/src/menu.asm
+++ b/src/menu.asm
@@ -72,11 +72,18 @@ cm_start:
     JSL $809B44 ; Handle HUD tilemap
     JSL ih_update_hud_code
 
-    JSL GameLoopExtras            ; check if game_loop_extras needs to be disabled
-    JSL restore_ppu_long          ; Restore PPU
-    JSL $82BE2F                   ; Queue Samus movement sound effects
-    JSL play_music_long           ; Play 2 lag frames of music and sound effects
-    JSL maybe_trigger_pause_long  ; Maybe trigger pause screen or return save confirmation selection
+    JSL GameLoopExtras ; check if game_loop_extras needs to be disabled
+    JSL restore_ppu_long ; Restore PPU registers and tilemaps
+
+    ; skip sound effects if not gameplay ($7-13 allowed)
+    %ai16()
+    LDA !GAMEMODE : CMP #$0006 : BMI .skipSFX
+    CMP #$0014 : BPL .skipSFX
+    JSL $82BE2F ; Queue Samus movement sound effects
+
+  .skipSFX
+    JSL play_music_long ; Play 2 lag frames of music and sound effects
+    JSL maybe_trigger_pause_long ; Maybe trigger pause screen or return save confirmation selection
 
     PLY : PLX : PLB
     PLP

--- a/src/misc.asm
+++ b/src/misc.asm
@@ -206,12 +206,6 @@ endif
     BRA $18
 
 
-; Adds frames when unpausing (nmi is turned off during vram transfers)
-; $80:A16B 22 4B 83 80 JSL $80834B[$80:834B]
-org $80A16B
-    JSL hook_unpause
-
-
 ; $82:8BB3 22 69 91 A0 JSL $A09169[$A0:9169]  ; Handles Samus getting hurt?
 org $828BB3
     JSL gamemode_end
@@ -273,28 +267,6 @@ hook_set_music_data:
 
   .fast_no_music
     JML $808F89
-}
-
-hook_unpause:
-{
-    ; RT room
-    LDA !ram_realtime_room : CLC : ADC.w #41 : STA !ram_realtime_room
-
-    ; RT seg
-    LDA !ram_seg_rt_frames : CLC : ADC.w #41 : STA !ram_seg_rt_frames
-    CMP.w #60 : BCC .done
-    SEC : SBC.w #60 : STA !ram_seg_rt_frames
-
-    LDA !ram_seg_rt_seconds : INC : STA !ram_seg_rt_seconds
-    CMP.w #60 : BCC .done
-    LDA #$0000 : STA !ram_seg_rt_seconds
-
-    LDA !ram_seg_rt_minutes : INC : STA !ram_seg_rt_minutes
-
-  .done
-    ; Replace overwritten logic to enable NMI
-    JSL $80834B
-    RTL
 }
 
 gamemode_end:

--- a/src/ramwatchmenu.asm
+++ b/src/ramwatchmenu.asm
@@ -390,7 +390,7 @@ RAMWatchCommonConfirm:
     dw ramwatch_common_addr2
     dw ramwatch_common_back
     dw #$0000
-    %cm_header("SELECT FROM ENEMY RAM")
+    %cm_header("SELECT HUD POSITION")
 
 ramwatch_common_addr1:
     %cm_jsl("Address 1 (Left)", .routine, #$0000)


### PR DESCRIPTION
Timers will now update when unpausing. The hijack we use to adjust for time missed during pause transitions turned out to be a good fit. I moved that hijack from misc.asm to infohud.asm as well.

When closing the practice menu from within the title or game over menus, the call to queue Samus movement sounds would trigger an endless grapple noise or the health alarm. Now it will check the gamemode before making that call.

Might add some other little things before 2.5.1 is wrapped up.