### PR TITLE
reload OOB tile viewer when loading a savestate

### DIFF
--- a/src/save.asm
+++ b/src/save.asm
@@ -112,6 +112,10 @@ post_load_state:
     LDA !MUSIC_TRACK : JSL !MUSIC_ROUTINE
 
   .music_done
+    ; Reload OOB tile viewer if enabled
+    LDA !ram_oob_watch_active : BEQ .tileviewer_done
+    JSL upload_sprite_oob_tiles
+  .tileviewer_done
     ; Reload BG3 GFX if minimap setting changed
     LDA !ram_minimap : CMP !SRAM_SAVED_MINIMAP : BEQ .rng
     JSL cm_transfer_original_tileset

--- a/src/tinystates.asm
+++ b/src/tinystates.asm
@@ -161,6 +161,10 @@ post_load_state:
     LDA !MUSIC_TRACK : JSL !MUSIC_ROUTINE
 
   .music_done
+    ; Reload OOB tile viewer if enabled
+    LDA !ram_oob_watch_active : BEQ .tileviewer_done
+    JSL upload_sprite_oob_tiles
+  .tileviewer_done
     ; Reload BG3 GFX if minimap setting changed
     LDA !ram_minimap : CMP !SRAM_SAVED_MINIMAP : BEQ .rng
     JSL cm_transfer_original_tileset


### PR DESCRIPTION
Now that the tile viewer setting is persistent, we need to make sure our sprite tiles are uploaded when loading a savestate while the tile viewer is enabled.