### PR TITLE
Simpler door scroll bug fix

### DIFF
--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -1500,6 +1500,7 @@ ih_set_picky_chozo_event_and_enemy_speed:
 ih_fix_scroll_offsets:
 {
     LDA !ram_fix_scroll_offsets : BEQ .nofix
+    LDA $B3 : AND #$FF00 : STA $B3
     LDA $B1 : AND #$FF00
     SEC
     RTS

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -1499,14 +1499,12 @@ ih_set_picky_chozo_event_and_enemy_speed:
 
 ih_fix_scroll_offsets:
 {
-    LDA !ram_fix_scroll_offsets : BEQ .done
-    %a8()
-    LDA $0911 : STA $B1 : STA $B5
-    LDA $0915 : STA $B3 : STA $B7
-    %a16()
+    LDA !ram_fix_scroll_offsets : BEQ .nofix
+    LDA $B1 : AND #$FF00
+    SEC
+    RTS
 
-  .done
-    ; overwritten code
+  .nofix
     LDA $B1 : SEC
     RTS
 }


### PR DESCRIPTION
This is a smaller fix for the door scrolling bug most commonly triggered by sparking to the Terminator door in Parlor. The bug appears to be caused by the BG1 scroll value becoming malformed such that it's not a multiple of $0100 (eg, the low byte may end being $02 or $03.) The glitch does not seem to affect or be caused by the BG2 layer scroll (map background graphics) or any vertical scrolling values.