### PR TITLE
Adds option to not update timers when riding elevators or grabbing items

### DIFF
--- a/src/defines.asm
+++ b/src/defines.asm
@@ -207,6 +207,8 @@
 !ram_seed_X = !WRAM_MENU_START+$60
 !ram_seed_Y = !WRAM_MENU_START+$62
 
+!ram_timers_autoupdate = !WRAM_MENU_START+$64
+
 ; ^ FREE SPACE ^ up to +$7E
 
 ; ------------------

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -178,7 +178,8 @@ print pc, " infohud start"
 ih_get_item_code:
 {
     PHA
-
+    LDA !ram_timers_autoupdate : BNE +
+    
     ; calculate lag frames
     LDA !ram_realtime_room : SEC : SBC !ram_transition_counter : STA !ram_last_room_lag
 
@@ -198,7 +199,7 @@ ih_get_item_code:
     PLA : STA $14
     PLA : STA $12
 
-    PLA
++   PLA
     JSL $80818E
     RTL
 }
@@ -432,6 +433,7 @@ ih_elevator_activation:
     ; Only update if we're in a room and activate an elevator.
     ; Otherwise this will also run when you enter a room already riding one.
     LDA !GAMEMODE : CMP #$0008 : BNE .done
+    LDA !ram_timers_autoupdate : BNE .done
 
     JSL ih_update_hud_early
 

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -1936,6 +1936,8 @@ endif
     dw #ih_lag
     dw #$FFFF
     dw #ih_ram_watch
+    dw #$FFFF
+    dw #ih_auto_update_timers
     dw #$0000
     %cm_header("INFOHUD")
 
@@ -2034,6 +2036,8 @@ ihmode_shottimer:
 !IH_MODE_RAMWATCH_INDEX = $0014
 ihmode_ramwatch:
     %cm_jsl("RAM Watch", #action_select_infohud_mode, #$0014)
+
+
 
 action_select_infohud_mode:
 {
@@ -2209,6 +2213,9 @@ ih_lag:
 
 ih_ram_watch:
     %cm_jsl("Customize RAM Watch", #ih_prepare_ram_watch_menu, #RAMWatchMenu)
+
+ih_auto_update_timers:
+    %cm_toggle_inverted("Auto update timers", !ram_timers_autoupdate, #$0001, #0)
 
 incsrc ramwatchmenu.asm
 


### PR DESCRIPTION
I needed something like this for better compatibility with sm_room_timer.
The room timer script fetches the room time from memory, but it might happen that it does so with a bit of a delay (>0.25s).
For most rooms this isn't an issue, but for rooms that have elevators or items right after the door transition (like after pit room or the hi jump entrance) this sometimes results in the wrong time being fetched by the script.
With this new option, one can now turn on/off the timer update when grabbing items and riding elevators, which minimizes the room timer issue.
(Naming of the option can likely be improved...)