### PR TITLE
Small custom preset upgrades, plus misc commits

### DIFF
--- a/src/crash.asm
+++ b/src/crash.asm
@@ -360,26 +360,6 @@ endif
     JMP CrashLoop
 }
 
-crash_toggle_bg:
-{
-    %a8()
-    LDA #$80 : STA $2100 ; enable forced blanking
-    LDA !ram_crash_bg : BEQ .enableBG
-    ; disable BG1/2 on main screen
-    LDA #$14 : STA $212C
-    BRA .done
-
-  .enableBG
-    ; disable BG1/2 on main screen
-    LDA #$17 : STA $212C
-
-  .done
-    LDA #$0F : STA $2100 ; disable forced blanking
-    LDA !ram_crash_bg : EOR #$01 : STA !ram_crash_bg
-    %a16()
-    RTS
-}
-
 CrashPageTable:
     dw CrashDump
     dw CrashMemViewer
@@ -1012,6 +992,26 @@ crash_cgram_transfer:
     PLP
     PHK : PLB
     RTL
+}
+
+crash_toggle_bg:
+{
+    %a8()
+    LDA #$80 : STA $2100 ; enable forced blanking
+    LDA !ram_crash_bg : BEQ .enableBG
+    ; disable BG1/2 and sprites on main/sub screen
+    LDA #$04 : STA $212C : STA $212D
+    BRA .done
+
+  .enableBG
+    ; enable BG1/2 and sprites on main/sub screen
+    LDA #$17 : STA $212C : STA $212D
+
+  .done
+    LDA #$0F : STA $2100 ; disable forced blanking
+    LDA !ram_crash_bg : EOR #$01 : STA !ram_crash_bg
+    %a16()
+    RTS
 }
 
 crash_tilemap_transfer:

--- a/src/crash.asm
+++ b/src/crash.asm
@@ -31,6 +31,7 @@
 !ram_crash_mem_viewer = !CRASHDUMP+$52
 !ram_crash_mem_viewer_bank = !CRASHDUMP+$54
 !ram_crash_temp = !CRASHDUMP+$56
+!ram_crash_bg = !CRASHDUMP+$58
 
 !ram_crash_input = !CRASHDUMP+$60
 !ram_crash_input_new = !CRASHDUMP+$62
@@ -268,6 +269,7 @@ CrashViewer:
 
     LDA #$0000 : STA !ram_crash_page : STA !ram_crash_palette : STA !ram_crash_cursor
     STA !ram_crash_input : STA !ram_crash_input_new
+    LDA #$0001 : STA !ram_crash_bg
     LDA !IH_CONTROLLER_PRI_NEW : STA !ram_crash_input_prev
     LDA #$0A44 : STA !ram_crash_mem_viewer
     LDA #$007E : STA !ram_crash_mem_viewer_bank
@@ -340,6 +342,7 @@ endif
 
   .decPalette
     LDA !ram_crash_palette : BNE .paletteDecrement
+    JSR crash_toggle_bg
     LDA #$0008
   .paletteDecrement
     DEC : STA !ram_crash_palette
@@ -347,6 +350,7 @@ endif
 
   .incPalette
     LDA !ram_crash_palette : CMP #$0007 : BMI .paletteIncrement
+    JSR crash_toggle_bg
     LDA #$FFFF
   .paletteIncrement
     INC : STA !ram_crash_palette
@@ -354,6 +358,26 @@ endif
   .updateCGRAM
     JSL crash_cgram_transfer
     JMP CrashLoop
+}
+
+crash_toggle_bg:
+{
+    %a8()
+    LDA #$80 : STA $2100 ; enable forced blanking
+    LDA !ram_crash_bg : BEQ .enableBG
+    ; disable BG1/2 on main screen
+    LDA #$14 : STA $212C
+    BRA .done
+
+  .enableBG
+    ; disable BG1/2 on main screen
+    LDA #$17 : STA $212C
+
+  .done
+    LDA #$0F : STA $2100 ; disable forced blanking
+    LDA !ram_crash_bg : EOR #$01 : STA !ram_crash_bg
+    %a16()
+    RTS
 }
 
 CrashPageTable:

--- a/src/customizemenu.asm
+++ b/src/customizemenu.asm
@@ -33,27 +33,28 @@ mc_paletteprofile:
     dl #!sram_custompalette_profile
     dw refresh_cgram_long
     db #$28, "Menu Palette", #$FF
-        db #$28, "     CUSTOM", #$FF ; CUSTOM should always be first
-        db #$28, "     TWITCH", #$FF
-        db #$28, "    DEFAULT", #$FF
-        db #$28, "    FIREBAT", #$FF
-        db #$28, " WARDRINKER", #$FF
-        db #$28, "        MM2", #$FF
-        db #$28, "      PTOIL", #$FF
-        db #$28, "     ZOHDIN", #$FF
-        db #$28, "    DARKXOA", #$FF
-        db #$28, "    MELONAX", #$FF
-        db #$28, " TOPSYTURVE", #$FF
-        db #$28, "        OST", #$FF
-        db #$28, "        JRP", #$FF
-        db #$28, "     LAYRUS", #$FF
-        db #$28, "      DAYNE", #$FF
-        db #$28, "DREAMCOWBOY", #$FF
-        db #$28, "       ZENI", #$FF
-        db #$28, "       GREY", #$FF
-        db #$28, "        RED", #$FF
-        db #$28, "     PURPLE", #$FF
-        db #$28, "        HUD", #$FF
+    db #$28, "     CUSTOM", #$FF ; CUSTOM should always be first
+    db #$28, "     TWITCH", #$FF
+    db #$28, "    DEFAULT", #$FF
+    db #$28, "    FIREBAT", #$FF
+    db #$28, " WARDRINKER", #$FF
+    db #$28, "        MM2", #$FF
+    db #$28, "      PTOIL", #$FF
+    db #$28, "     ZOHDIN", #$FF
+    db #$28, "    DARKXOA", #$FF
+    db #$28, "    MELONAX", #$FF
+    db #$28, " TOPSYTURVE", #$FF
+    db #$28, "        OST", #$FF
+    db #$28, "        JRP", #$FF
+    db #$28, "     LAYRUS", #$FF
+    db #$28, "      DAYNE", #$FF
+    db #$28, "DREAMCOWBOY", #$FF
+    db #$28, "       ZENI", #$FF
+    db #$28, "       DYCE", #$FF
+    db #$28, "       GREY", #$FF
+    db #$28, "        RED", #$FF
+    db #$28, "     PURPLE", #$FF
+    db #$28, "        HUD", #$FF
     db #$FF
 
 mc_palette2custom:
@@ -435,6 +436,7 @@ PaletteProfileTables:
     dw #DayneProfileTable
     dw #DreamCowboyProfileTable
     dw #ZeniProfileTable
+    dw #DyceProfileTable
     dw #GreyProfileTable
     dw #RedProfileTable
     dw #PurpleProfileTable
@@ -488,6 +490,9 @@ DreamCowboyProfileTable:
 
 ZeniProfileTable:
     dw $7D40, $3900, $7F00, $0000, $0000, $7FE0, $7EA0, $7FE0, $0000, $0000, $7E00
+
+DyceProfileTable:
+    dw $5DC0, $5DC0, $77BD, $2060, $0000, $7FFF, $7FFF, $7FFF, $5DC0, $5DC0, $7FFF
 
 GreyProfileTable:
     dw $0012, $1CE7, $3DEF, $0C63, $1CE7, $3DEF, $0EE3, $0012, $0C63, $1CE7, $3DEF

--- a/src/gamemode.asm
+++ b/src/gamemode.asm
@@ -302,6 +302,8 @@ endif
   .increment_slot
     INC : STA !sram_custom_preset_slot
     ASL : TAX : LDA.l NumberGFXTable,X : STA !HUD_TILEMAP+$7C
+    LDA !sram_last_preset : BMI .done_preset_slot
+    LDA #$0000 : STA !sram_last_preset
     ; CLC to continue normal gameplay after incrementing preset slot
     CLC : JMP skip_pause
 
@@ -311,6 +313,9 @@ endif
   .decrement_slot
     DEC : STA !sram_custom_preset_slot
     ASL : TAX : LDA.l NumberGFXTable,X : STA !HUD_TILEMAP+$7C
+    LDA !sram_last_preset : BMI .done_preset_slot
+    LDA #$0000 : STA !sram_last_preset
+  .done_preset_slot
     ; CLC to continue normal gameplay after decrementing preset slot
     CLC : JMP skip_pause
 

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -3357,7 +3357,7 @@ PhantoonMenu:
 
 
 phan_phase_1_table:
-    dw #$003F, #$0020, #$0008, #$0002, #$0010, #$0004, #$0001
+    dw #$003F, #$0020, #$0004, #$0002, #$0010, #$0008, #$0001
     dw #$0030, #$000C, #$0003, #$002A, #$0015, #$003C, #$0000
 
 phan_phase_2_table:
@@ -3418,7 +3418,7 @@ phan_fast_left_1:
     %cm_toggle_bit("#1 Fast Left", !ram_phantoon_rng_round_1, #$0020, phan_set_phan_first_phase)
 
 phan_mid_left_1:
-    %cm_toggle_bit("#1 Mid  Left", !ram_phantoon_rng_round_1, #$0008, phan_set_phan_first_phase)
+    %cm_toggle_bit("#1 Mid  Left", !ram_phantoon_rng_round_1, #$0004, phan_set_phan_first_phase)
 
 phan_slow_left_1:
     %cm_toggle_bit("#1 Slow Left", !ram_phantoon_rng_round_1, #$0002, phan_set_phan_first_phase)
@@ -3427,7 +3427,7 @@ phan_fast_right_1:
     %cm_toggle_bit("#1 Fast Right", !ram_phantoon_rng_round_1, #$0010, phan_set_phan_first_phase)
 
 phan_mid_right_1:
-    %cm_toggle_bit("#1 Mid  Right", !ram_phantoon_rng_round_1, #$0004, phan_set_phan_first_phase)
+    %cm_toggle_bit("#1 Mid  Right", !ram_phantoon_rng_round_1, #$0008, phan_set_phan_first_phase)
 
 phan_slow_right_1:
     %cm_toggle_bit("#1 Slow Right", !ram_phantoon_rng_round_1, #$0001, phan_set_phan_first_phase)

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -357,22 +357,22 @@ presets_current:
     dl #!sram_preset_category
     dw #.routine
     db #$28, "CURRENT PRESET", #$FF
-        db #$28, "       PRKD", #$FF
-        db #$28, "       KPDR", #$FF
-        db #$28, "  100% LATE", #$FF
-        db #$28, " 100% EARLY", #$FF
-        db #$28, "        RBO", #$FF
-        db #$28, "       PKRD", #$FF
-        db #$28, "     KPDR25", #$FF
-        db #$28, " GT CLASSIC", #$FF
-        db #$28, "    GT MAX%", #$FF
-        db #$28, "    14% ICE", #$FF
-        db #$28, "  14% SPEED", #$FF
-        db #$28, "   100% MAP", #$FF
-        db #$28, "  NIN POWER", #$FF
-        db #$28, "   ALL KPDR", #$FF
-        db #$28, "   ALL PKDR", #$FF
-        db #$28, "   ALL PRKD", #$FF
+    db #$28, "       PRKD", #$FF
+    db #$28, "       KPDR", #$FF
+    db #$28, "  100% LATE", #$FF
+    db #$28, " 100% EARLY", #$FF
+    db #$28, "        RBO", #$FF
+    db #$28, "       PKRD", #$FF
+    db #$28, "     KPDR25", #$FF
+    db #$28, " GT CLASSIC", #$FF
+    db #$28, "    GT MAX%", #$FF
+    db #$28, "    14% ICE", #$FF
+    db #$28, "  14% SPEED", #$FF
+    db #$28, "   100% MAP", #$FF
+    db #$28, "  NIN POWER", #$FF
+    db #$28, "   ALL KPDR", #$FF
+    db #$28, "   ALL PKDR", #$FF
+    db #$28, "   ALL PRKD", #$FF
     db #$FF
   .routine
     LDA #$0000 : STA !sram_last_preset

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -235,6 +235,9 @@ presets_custom_preset_slot:
   .routine
     ; ignore if not A, X, or Y
     LDA !IH_CONTROLLER_PRI_NEW : BIT #$40C0 : BNE .submenu
+    LDA !sram_last_preset : BMI .exit
+    LDA #$0000 : STA !sram_last_preset
+  .exit
     RTL
   .submenu
     ; undo increment from execute_numfield

--- a/src/menu.asm
+++ b/src/menu.asm
@@ -3066,6 +3066,10 @@ execute_custom_preset:
     %a8()
     LDA [!DP_CurrentMenu] : STA !sram_custom_preset_slot
     %a16()
+    LDA !sram_last_preset : BMI .sfx
+    LDA #$0000 : STA !sram_last_preset
+
+  .sfx
     %sfxconfirm()
     JSL cm_previous_menu
 

--- a/src/misc.asm
+++ b/src/misc.asm
@@ -262,6 +262,7 @@ else
     NOP  ; Add 2 more clock cycles
     NOP  ; Add 2 more clock cycles
 endif
+    INC #3 ; Add 21 more clock cycles including the INCs)
     TAX
   .lagloop
     DEX : BNE .lagloop
@@ -282,6 +283,7 @@ if !FEATURE_SD2SNES
 else
     INC  ; Add 1 loop (7 clock cycles including the INC)
 endif
+    INC #3 ; Add 21 more clock cycles including the INCs)
     TAX
   .vanilla_lagloop
     DEX : BNE .vanilla_lagloop

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -235,10 +235,15 @@ preset_load_preset:
   .check_load
     ; check if custom preset is being loaded
     LDA !ram_custom_preset : BEQ .category_preset
+
+  .custom_preset
     JSL custom_preset_load
+    LDA #$5AFE : STA !sram_last_preset
+    LDA #$0000 : STA !ram_load_preset
     BRA .done
 
   .category_preset
+    LDA !ram_load_preset : CMP #$5AFE : BEQ .custom_preset
     JSR category_preset_load
 
   .done

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -536,6 +536,7 @@ endif
     STZ !ELEVATOR_STATUS
     STZ !HEALTH_BOMB_FLAG
     STZ !MESSAGE_BOX_INDEX
+    STZ $1E75 ; Save Station Lockout flag
     STZ $0795 : STZ $0797  ; Clear door transition flags
     TDC : STA !ram_transition_flag
     JSL init_heat_damage_ram

--- a/src/presets/gtclassic_data.asm
+++ b/src/presets/gtclassic_data.asm
@@ -388,6 +388,7 @@ preset_gtclassic_brinstar_dachora_room:
     dw $09C2, $00BD  ; Health
     dw $09CA, $0005  ; Supers
     dw $09CC, $0005  ; Max supers
+    dw $09D2, $0002  ; Currently selected item
     dw $0A1C, $0019  ; Samus position/state
     dw $0A1E, $0308  ; More position/state
     dw $0AF6, $0052  ; Samus X
@@ -408,6 +409,7 @@ preset_gtclassic_brinstar_big_pink:
     dw $09C2, $00B3  ; Health
     dw $09C6, $0002  ; Missiles
     dw $09CA, $0004  ; Supers
+    dw $09D2, $0000  ; Currently selected item
     dw $0A1C, $0001  ; Samus position/state
     dw $0A1E, $0008  ; More position/state
     dw $0AF6, $0692  ; Samus X
@@ -901,7 +903,7 @@ preset_gtclassic_bootless_upper_norfair_green_gate_glitch:
     dw $0917, $0000  ; Layer 2 X position
     dw $0919, $0180  ; Layer 2 Y position
     dw $09CE, $0004  ; Pbs
-    dw $09D2, $0000  ; Currently selected item
+    dw $09D2, $0002  ; Currently selected item
     dw $0A1C, $0002  ; Samus position/state
     dw $0A1E, $0004  ; More position/state
     dw $0AF6, $006E  ; Samus X
@@ -920,6 +922,7 @@ preset_gtclassic_bootless_upper_norfair_gt_code:
     dw $0919, $0178  ; Layer 2 Y position
     dw $09C2, $001A  ; Health
     dw $09CA, $0000  ; Supers
+    dw $09D2, $0000  ; Currently selected item
     dw $0AF6, $0024  ; Samus X
     dw $0AFA, $028B  ; Samus Y
     dw #$FFFF
@@ -1141,7 +1144,7 @@ preset_gtclassic_hi_jump_upper_norfair_green_gate_glitch:
     dw $0911, $0000  ; Screen X position in pixels
     dw $0913, $4000  ; Screen subpixel Y position
     dw $09CE, $0004  ; Pbs
-    dw $09D2, $0000  ; Currently selected item
+    dw $09D2, $0002  ; Currently selected item
     dw $0917, $0000  ; Layer 2 X position
     dw $0919, $0180  ; Layer 2 Y position
     dw $0A1C, $0002  ; Samus position/state
@@ -1162,6 +1165,7 @@ preset_gtclassic_hi_jump_upper_norfair_gt_code:
     dw $0919, $017A  ; Layer 2 Y position
     dw $09C2, $0097  ; Health
     dw $09CA, $0003  ; Supers
+    dw $09D2, $0000  ; Currently selected item
     dw $0AF6, $0024  ; Samus X
     dw $0AFA, $028B  ; Samus Y
     dw #$FFFF
@@ -1827,6 +1831,7 @@ preset_gtclassic_wrecked_ship_basement:
     dw $0917, $0300  ; Layer 2 X position
     dw $0919, $0557  ; Layer 2 Y position
     dw $09CA, $000F  ; Supers
+    dw $09D2, $0002  ; Currently selected item
     dw $0AF6, $045F  ; Samus X
     dw $0AFA, $07BB  ; Samus Y
     dw $D8C0, $8010  ; Doors
@@ -1842,6 +1847,7 @@ preset_gtclassic_wrecked_ship_phantoon:
     dw $0919, $0000  ; Layer 2 Y position
     dw $09CA, $000E  ; Supers
     dw $09CE, $000C  ; Pbs
+    dw $09D2, $0000  ; Currently selected item
     dw $0AF6, $04CE  ; Samus X
     dw $0AFA, $008B  ; Samus Y
     dw $D8C0, $8030  ; Doors
@@ -2112,6 +2118,7 @@ preset_gtclassic_tourian_zeb_skip:
     dw $0915, $021D  ; Screen Y position in pixels
     dw $0919, $0195  ; Layer 2 Y position
     dw $09CA, $000E  ; Supers
+    dw $09D2, $0002  ; Currently selected item
     dw $0A1C, $0002  ; Samus position/state
     dw $0A1E, $0004  ; More position/state
     dw $0AF6, $0047  ; Samus X
@@ -2130,6 +2137,7 @@ preset_gtclassic_tourian_mother_brain_2:
     dw $0919, $0000  ; Layer 2 Y position
     dw $09C6, $005B  ; Missiles
     dw $09CA, $0001  ; Supers
+    dw $09D2, $0000  ; Currently selected item
     dw $0AF6, $00CF  ; Samus X
     dw $0AFA, $009B  ; Samus Y
     dw $D820, $0FC5  ; Events

--- a/src/spritefeat.asm
+++ b/src/spritefeat.asm
@@ -816,15 +816,17 @@ draw_custom_boss_hitbox:
     RTS
 
   .mother_brain
+    ; check which phase MB is in, 2 = 2nd phase
     LDA $7E7800 : CMP #$0002 : BMI .end
 
+    ; load hitbox enable bitflags
     LDA $7E7808 : BEQ .end : STA $C1
     LDX #$0000 : LDY !OAM_STACK_POINTER ; X = enemy index
     LDA #$00A9 : STA $12 ; MB bank
 
     ; draw body hitboxes
     LSR $C1 : BCC .head
-    LDA #$B429 : STA $10
+    LDA #$B429 : STA $10 ; hitbox definition pointer, bank $A9
 
     ; first body hitbox
     LDA #$FFE0 : STA $14 ; left offset
@@ -843,7 +845,7 @@ draw_custom_boss_hitbox:
   .head
     ; draw head hitboxes
     LSR $C1 : BCC .neck
-    LDA #$B43B : STA $10
+    LDA #$B43B : STA $10 ; hitbox definition pointer, bank $A9
     LDX #$0040
 
     ; first head hitbox


### PR DESCRIPTION
- The "load last preset" shortcut is now compatible with custom presets
- Pressing left/right on a custom preset slot page will change to the prev/next page
- Fixed reversed first round mid patterns in Phantoon RNG controls
- Fixed inoperable save station after loading a preset into a save room
- Optimizations for `ih_game_loop_code` and compensation in artificial lag
- Added Dyce menu palette profile
Edit:
- Cycle through palettes to toggle gameplay backgrounds in the crash handler