### PR TITLE
Add "speedrun" timer mode that includes skipped cutscenes and doors

### DIFF
--- a/src/cutscenes.asm
+++ b/src/cutscenes.asm
@@ -28,8 +28,11 @@ cutscenes_door_transition:
     PHX
     JSR ($AE76,x)
     PLX
-    BCC .slow
+    BCC .again
     RTS             ; If the door transition is done, don't run it again.
+  .again
+    LDY #$0001
+    JSL ih_adjust_realtime
   .slow
     JMP ($AE76,x)
 }
@@ -119,12 +122,14 @@ cutscenes_nintendo_splash:
 
 cutscenes_add_elevator_speed:
 {
-    CLC
     LDA !sram_fast_elevators : BEQ .slow
+    LDY #$0002 : JSL ih_adjust_realtime
+    CLC
     LDA $0F80,x : ADC #$8000 : STA $0F80,x
     LDA $0F7E,x : ADC #$0004 : STA $0F7E,x
     RTL
   .slow
+    CLC
     LDA $0F80,x : ADC #$8000 : STA $0F80,x
     LDA $0F7E,x : ADC #$0001 : STA $0F7E,x
     RTL
@@ -132,12 +137,14 @@ cutscenes_add_elevator_speed:
 
 cutscenes_sub_elevator_speed:
 {
-    SEC
     LDA !sram_fast_elevators : BEQ .slow
+    LDY #$0002 : JSL ih_adjust_realtime
+    SEC
     LDA $0F80,x : SBC #$8000 : STA $0F80,x
     LDA $0F7E,x : SBC #$0004 : STA $0F7E,x
     RTL
   .slow
+    SEC
     LDA $0F80,x : SBC #$8000 : STA $0F80,x
     LDA $0F7E,x : SBC #$0001 : STA $0F7E,x
     RTL

--- a/src/defines.asm
+++ b/src/defines.asm
@@ -95,7 +95,9 @@
 !ram_auto_save_state                = !WRAM_START+$82
 !ram_lag_counter                    = !WRAM_START+$84
 
-!WRAM_PERSIST_START = !ram_lag_counter+$02
+!ram_kraid_adjust_timer             = !WRAM_START+$86
+
+!WRAM_PERSIST_START = !ram_kraid_adjust_timer+$02
 ; ----------------------------------------------------------
 ; Variables below this point are PERSISTENT -- they maintain
 ; their value across savestates. Use this section for
@@ -286,7 +288,7 @@
 ; SRAM
 ; -----
 
-!SRAM_VERSION = $0013
+!SRAM_VERSION = $0014
 
 !SRAM_START = $702000
 
@@ -619,6 +621,14 @@ else
 !sram_custom_preset_names = !sram_custom_preset_names_normal
 endif
 
+if !FEATURE_PAL
+!FPS = #$0032
+!FPS_8BIT = #$32
+else
+!FPS = #$003C
+!FPS_8BIT = #$3C
+endif
+
 !DP_MenuIndices = $00 ; 0x4
 !DP_CurrentMenu = $04 ; 0x4
 !DP_Address = $08 ; 0x4
@@ -748,9 +758,8 @@ endif
 
 !FANFARE_TOGGLE = #$0001
 !FANFARE_TOGGLE_8BIT = #$01
-!FANFARE_ADJUST_REALTIME = #$0002
-!FANFARE_ADJUST_REALTIME_8BIT = #$02
-
+!FRAME_COUNTER_ADJUST_REALTIME = #$0002
+!FRAME_COUNTER_ADJUST_REALTIME_8BIT = #$02
 
 ; ----------
 ; Save/Load

--- a/src/fanfare.asm
+++ b/src/fanfare.asm
@@ -180,28 +180,11 @@ hook_message_box_wait:
     DEX
     BNE .nofanfareloop
 
-    LDA !sram_fanfare : BIT !FANFARE_ADJUST_REALTIME_8BIT : BEQ .done
     %a16()
-    LDA !ram_realtime_room : CLC : ADC #$0148 : STA !ram_realtime_room
-
-    ; adding 5:28 to seg timer
-    STZ $12
-    LDA !ram_seg_rt_frames : CLC : ADC #$001C : STA !ram_seg_rt_frames
-    CMP #$003C : BMI .add_seconds
-    SEC : SBC #$003C : STA !ram_seg_rt_frames : INC $12
-
-  .add_seconds
-    LDA !ram_seg_rt_seconds : CLC : ADC #$0005 : ADC $12 : STA !ram_seg_rt_seconds
-    STZ $12
-    CMP #$003C : BMI .add_minutes
-    SEC : SBC #$003C : STA !ram_seg_rt_seconds : INC $12
-
-  .add_minutes
-    LDA $12 : BEQ .done
-    CLC : ADC !ram_seg_rt_minutes : STA !ram_seg_rt_minutes
-
-  .done
+    LDY #328
+    JSL ih_adjust_realtime
     %a8()
+
     RTS
 
   .fanfareloop       ; original logic

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -347,6 +347,16 @@ ih_after_room_transition:
     ; Reset realtime and gametime/transition timers
     LDA #$0000 : STA !ram_realtime_room : STA !ram_transition_counter
 
+    LDA !ram_kraid_adjust_timer : BEQ .skipKraidTimer
+if !FEATURE_PAL
+    LDY #$00F9
+else
+    LDY #$012B
+endif
+    JSL ih_adjust_realtime
+    LDA #$0000 : STA !ram_kraid_adjust_timer
+
+  .skipKraidTimer
     JSL init_heat_damage_ram
     JSL init_physics_after_transition
 
@@ -572,7 +582,7 @@ ih_update_hud_code:
 
   .mmRoomTimer
     STZ $4205
-    LDA !sram_frame_counter_mode : BNE .mmInGameTimer
+    LDA !sram_frame_counter_mode : BIT #$0001 : BNE .mmInGameTimer
     LDA !IH_DECIMAL : STA !HUD_TILEMAP+$B4
     LDA !ram_last_realtime_room
     BRA .mmCalculateTimer
@@ -617,7 +627,7 @@ endif
 
   .pickRoomTimer
     STZ $4205
-    LDA !sram_frame_counter_mode : BNE .inGameRoomTimer
+    LDA !sram_frame_counter_mode : BIT #$0001 : BNE .inGameRoomTimer
     LDA !IH_DECIMAL : STA !HUD_TILEMAP+$42
     LDA !ram_last_realtime_room
     BRA .calculateRoomTimer
@@ -714,7 +724,7 @@ endif
     LDX #$00C2 : JSR Draw2
 
   .pickSegmentTimer
-    LDA !sram_frame_counter_mode : BNE .inGameSegmentTimer
+    LDA !sram_frame_counter_mode : BIT #$0001 : BNE .inGameSegmentTimer
     LDA.w #!ram_seg_rt_frames : STA $00
     LDA !WRAM_BANK : STA $02
     BRA .drawSegmentTimer
@@ -738,7 +748,7 @@ endif
     LDA [$00] : LDX #$00AE : JSR Draw3
 
     ; Draw decimal/hyphen seperators
-    LDA !sram_frame_counter_mode : BNE .ingameSeparators
+    LDA !sram_frame_counter_mode : BIT #$0001 : BNE .ingameSeparators
     LDA !IH_DECIMAL : STA !HUD_TILEMAP+$B4 : STA !HUD_TILEMAP+$BA
     BRA .blankEnd
 
@@ -1585,6 +1595,30 @@ ih_shinespark_code:
     DEC
     STA !ram_armed_shine_duration
     STA !SAMUS_SHINE_TIMER
+    RTL
+}
+
+; If the frame counter is set to "SPEEDRUN" mode, adds the number of frames in Y to the room and segment timers.
+ih_adjust_realtime:
+{
+    LDA !sram_frame_counter_mode : BIT !FRAME_COUNTER_ADJUST_REALTIME : BEQ .done
+
+    TYA
+    ; add time to segment timer frames, and divide by 60
+    CLC : ADC !ram_seg_rt_frames : STA $4204
+    TYA : %i8() : LDY !FPS_8BIT : STY $4206
+
+    PHA : CLC : ADC !ram_realtime_room : STA !ram_realtime_room
+    LDA $4216 : STA !ram_seg_rt_frames
+    LDA $4214 : CLC : ADC !ram_seg_rt_seconds : STA $4204 : STY $4206
+    PLA : CLC : ADC !ram_transition_counter : STA !ram_transition_counter
+
+    CLC : LDA !ram_seg_rt_minutes
+    ADC $4214 : STA !ram_seg_rt_minutes
+    LDA $4216 : STA !ram_seg_rt_seconds
+
+    %i16()
+  .done
     RTL
 }
 

--- a/src/init.asm
+++ b/src/init.asm
@@ -96,6 +96,7 @@ init_sram:
     CMP #$0010 : BEQ .sram_upgrade_10to11
     CMP #$0011 : BEQ .sram_upgrade_11to12
     CMP #$0012 : BEQ .sram_upgrade_12to13
+    CMP #$0013 : BEQ .sram_upgrade_13to14
     JSL init_sram_upto9
 
   .sram_upgrade_9toA
@@ -138,6 +139,14 @@ init_sram:
 
   .sram_upgrade_12to13
     TDC : STA !sram_custom_header
+
+  .sram_upgrade_13to14
+    ; "skip fanfares, but adjust timer" option has been replaced with "speedrun" timer mode
+    LDA !sram_fanfare : BIT #$0002 : BEQ .timer_adjust_done
+    LDA !sram_fanfare : AND #$0001 : STA !sram_fanfare
+    LDA !sram_frame_counter_mode : BNE .timer_adjust_done
+    LDA !FRAME_COUNTER_ADJUST_REALTIME : STA !sram_frame_counter_mode
+  .timer_adjust_done
 
     LDA #!SRAM_VERSION : STA !sram_initialized
     RTS

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -2574,7 +2574,6 @@ ih_goto_timers:
 
 IHTimerMenu:
     dw #ih_room_counter
-    dw #ih_fanfare_timer_adjust
     dw #ih_lag_counter
     dw #ih_auto_update_timers
     dw #$FFFF
@@ -2590,10 +2589,8 @@ ih_room_counter:
     db #$28, "Frame Counters", #$FF
     db #$28, "   REALTIME", #$FF
     db #$28, "     INGAME", #$FF
+    db #$28, "   SPEEDRUN", #$FF
     db #$FF
-
-ih_fanfare_timer_adjust:
-    %cm_toggle_bit("Adjust Fanfare Timers", !sram_fanfare, !FANFARE_ADJUST_REALTIME, #0)
 
 ih_lag_counter:
     dw !ACTION_CHOICE

--- a/src/symbols.asm
+++ b/src/symbols.asm
@@ -97,6 +97,8 @@ ram_fail_count = !ram_fail_count ; !WRAM_START+$80
 ram_auto_save_state = !ram_auto_save_state ; !WRAM_START+$82
 ram_lag_counter = !ram_lag_counter ; !WRAM_START+$84
 
+ram_kraid_adjust_timer = !ram_kraid_adjust_timer ; !WRAM_START+$86
+
 ; ----------------------------------------------------------
 ; Variables below this point are PERSISTENT -- they maintain
 ; their value across savestates. Use this section for

--- a/web/data/help.mdx
+++ b/web/data/help.mdx
@@ -129,8 +129,8 @@ If you experience crashes or severe glitches when using savestates, your platfor
 |                               | This is to compensate for the lack of a minimap on the HUD which would normally consume CPU cycles.
 | - Customize RAM Watch         | Setup addresses to be monitored by the RAM Watch HUD mode. Address 1 will appear in the bottom-left corner of the HUD, while Address 2 appears just to the right of Address 1. Memory at these locations can be edited by configuring a Value and selecting 'Write to Address'. Toggle 'Lock Value' to automatically write the value once every frame. RAM Watch must must be the selected HUD mode to continue writing to the address. Only one byte of hex can be configured at a time in the menu. 'Hi' refers to the first byte, while 'Lo' refers to the second. Set the Hi Address to 0D and the Lo Address to EC to monitor the memory address $0DEC, which stores the counter for Samus direction changes while held by Draygon (among other uses). You can find lists of known RAM addresses by selecting 'Select Common Addresses'.
 | **Timer Settings**            | Located within the Infohud menu
-| - Frame Counters              | Toggle the room timer in the top-right of the HUD between realtime and gametime.
-| - Adjust Fanfare Timers       | Adds 328 frames to the realtime timer for each item collected with fanfare music off.
+| - Frame Counters              | Toggle the room timer in the top-right of the HUD between realtime, gametime, and "speedrun time".
+|                               | - Speedrun time is like realtime, except it includes time that was skipped due to practice hack features like shortened item fanfares, boss intros, door transitions, or elevators. This way, rooms and segments measured in the practice hack can be accurately compared to times from an actual run.
 | - Transition Lag              | Toggle the door time to include the full length of the room transition.
 | - Auto-Update Timers          | Option to turn off room timer updates when riding elevators or grabbign items
 | - Reset Segment in Next Room  | Sets the segment timer to reset automatically when exiting the next door transition.


### PR DESCRIPTION
Removes the "Adjust Fanfare Timer" option. In its place, the "Realtime/Ingame" timer selector gets a third option, called "Speedrun" (could be renamed to "Vanilla" or "Adjusted" or something). This option is real-time except as it would be during a run of the vanilla game, so skipped item fanfares & boss intros, as well as fast doors and elevators, have the skipped time added back in to the room and segment timers.

Upon upgrade, users who had the "adjust fanfare" option turned on and their timer set to realtime will automatically have their timer changed to speedrun mode.