### PR TITLE
Fix fanfare so when you skip save or select no then save is skipped

### DIFF
--- a/src/fanfare.asm
+++ b/src/fanfare.asm
@@ -356,14 +356,19 @@ hook_unpause_play_sound:
 
 hook_end_fanfare:
 {
+    ; save answer
+    PHA
     LDA !sram_healthalarm : CMP #$0004 : BNE .done_health_alarm
     LDA #$0002 : JSL $80914D
   .done_health_alarm
+    ; initialize water physics in case we just collected gravity or space jump
+    JSL init_physics_ram
+    ; restore answer
+    PLA
     ; original logic
     PLY : PLX
     PLB : PLP
-    ; initialize water physics in case we just collected gravity or space jump
-    JML init_physics_ram
+    RTL
 }
 
 %endfree(85)

--- a/src/main.asm
+++ b/src/main.asm
@@ -16,7 +16,7 @@ lorom
 !VERSION_MAJOR = 2
 !VERSION_MINOR = 7
 !VERSION_BUILD = 1
-!VERSION_REV   = 1
+!VERSION_REV   = 2
 
 table ../resources/normal.tbl
 print ""

--- a/web/data/changelog.mdx
+++ b/web/data/changelog.mdx
@@ -11,6 +11,7 @@
 - Add bootless up in two room strat, and kraid arm and mouth hitboxes (2.7.1)
 - Workaround audio popping issue with music off by muting track 4 and playing it instead of nothing (2.7.1)
 - Corrections for KPDR 25% presets (2.7.1.1)
+- Fix save stations so when you skip save or select no then save is skipped (2.7.1.2)
 
 # Version 2.6.x
 - Optimize kraid rock projectiles to reduce lag when Kraid rises (2.6.0)

--- a/web/data/config.json
+++ b/web/data/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Super Metroid Practice Hack",
-    "version": "2.7.1.1",
+    "version": "2.7.1.2",
     "variants": ["NTSC", "PAL"],
     "base": {
         "NTSC": {


### PR DESCRIPTION
Looks like I made a half-baked solution here.

The silly thing is I *know* I investigated the return value of this fanfare method and I believe I determined there were two callers I would need to modify if I trampled the return value... and then I just didn't do anything about it.  It's like I mentally marked off the work as done when it was definitely not done.

Anyway I think preserving the return value is simpler and I should have just done that the first time.

Planning to test and release later today.