### PR TITLE
Add dash speed InfoHUD mode

### DIFF
--- a/src/infohudmodes.asm
+++ b/src/infohudmodes.asm
@@ -18,6 +18,7 @@
     dw status_lagcounter
     dw status_cpuusage
     dw status_hspeed
+    dw status_dashspeed
     dw status_vspeed
     dw status_quickdrop
     dw status_walljump
@@ -766,6 +767,19 @@ status_hspeed:
     LDA.w HexGFXTable,Y : STA !HUD_TILEMAP+$8E
 
   .done
+    RTS
+}
+
+status_dashspeed:
+{
+    LDA !SAMUS_X_RUNSPEED : ASL : TAY
+    LDA.w HexGFXTable,Y : STA !HUD_TILEMAP+$8A
+
+    LDA !IH_DECIMAL : STA !HUD_TILEMAP+$8C
+
+    LDA !SAMUS_X_SUBRUNSPEED+1 : AND #$00F0 : LSR #3 : TAY
+    LDA.w HexGFXTable,Y : STA !HUD_TILEMAP+$8E
+
     RTS
 }
 

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -1622,6 +1622,7 @@ DisplayModeMenu:
     dw ihmode_lagcounter
     dw ihmode_cpuusage
     dw ihmode_hspeed
+    dw ihmode_dashspeed
     dw ihmode_vspeed
     dw ihmode_quickdrop
     dw ihmode_walljump
@@ -1685,43 +1686,46 @@ ihmode_cpuusage:
 ihmode_hspeed:
     %cm_jsl("Horizontal Speed", #action_select_infohud_mode, #$000C)
 
+ihmode_dashspeed:
+    %cm_jsl("Dash Speed", #action_select_infohud_mode, #$000D)
+
 ihmode_vspeed:
 !IH_MODE_VSPEED_INDEX = #$000D
-    %cm_jsl("Vertical Speed", #action_select_infohud_mode, #$000D)
+    %cm_jsl("Vertical Speed", #action_select_infohud_mode, #$000E)
 
 ihmode_quickdrop:
-    %cm_jsl("Quickdrop Trainer", #action_select_infohud_mode, #$000E)
+    %cm_jsl("Quickdrop Trainer", #action_select_infohud_mode, #$000F)
 
 ihmode_walljump:
 !IH_MODE_WALLJUMP_INDEX = #$000F
-    %cm_jsl("Walljump Trainer", #action_select_infohud_mode, #$000F)
+    %cm_jsl("Walljump Trainer", #action_select_infohud_mode, #$0010)
 
 ihmode_countdamage:
 !IH_MODE_COUNTDAMAGE_INDEX = #$0010
-    %cm_jsl("Boss Damage Counter", #action_select_infohud_mode, #$0010)
+    %cm_jsl("Boss Damage Counter", #action_select_infohud_mode, #$0011)
 
 ihmode_armpump:
 !IH_MODE_ARMPUMP_INDEX = #$0011
-    %cm_jsl("Arm Pump Trainer", #action_select_infohud_mode, #$0011)
+    %cm_jsl("Arm Pump Trainer", #action_select_infohud_mode, #$0012)
 
 ihmode_pumpcounter:
-    %cm_jsl("Arm Pump Counter", #action_select_infohud_mode, #$0012)
+    %cm_jsl("Arm Pump Counter", #action_select_infohud_mode, #$0013)
 
 ihmode_xpos:
-    %cm_jsl("X Position", #action_select_infohud_mode, #$0013)
+    %cm_jsl("X Position", #action_select_infohud_mode, #$0014)
 
 ihmode_ypos:
-    %cm_jsl("Y Position", #action_select_infohud_mode, #$0014)
+    %cm_jsl("Y Position", #action_select_infohud_mode, #$0015)
 
 ihmode_shottimer:
 !IH_MODE_SHOTTIMER_INDEX = #$0015
-    %cm_jsl("Shot Timer", #action_select_infohud_mode, #$0015)
+    %cm_jsl("Shot Timer", #action_select_infohud_mode, #$0016)
 
 ihmode_ramwatch:
 !IH_MODE_RAMWATCH_INDEX = #$0016
-    %cm_jsl("Custom RAM Watch", #action_select_infohud_mode, #$0016)
+    %cm_jsl("Custom RAM Watch", #action_select_infohud_mode, #$0017)
 
-!IH_MODE_COUNT = #$0017
+!IH_MODE_COUNT = #$0018
 action_select_infohud_mode:
 {
     TYA : STA !sram_display_mode
@@ -1753,6 +1757,7 @@ ih_display_mode:
     db #$28, "LAG COUNTER", #$FF
     db #$28, "  CPU USAGE", #$FF
     db #$28, "HORIZ SPEED", #$FF
+    db #$28, " DASH SPEED", #$FF
     db #$28, " VERT SPEED", #$FF
     db #$28, " QUICK DROP", #$FF
     db #$28, "  WALL JUMP", #$FF


### PR DESCRIPTION
This adds a "Dash Speed" InfoHUD mode option. This is like "Horizontal Speed" but without the component of "momentum" (a.k.a. "base speed"), only the component that counts how many frames dash has been held while running. PJ's bank logs refer to this as "extra run speed" and we could call it that, but I was thinking "Dash Speed" may be more intuitive.

Being able to see dash speed can be useful in many ways. One common example is for learning to do "tricky dash jumps" where with Speed Booster (but no Hi-Jump) you run and jump with a dash speed of exactly 2.0 or 2.1, resulting in a dramatically higher jump. As long as this dash speed is maintained, it also gives higher jumps with Space Jump, Spring Ball bounces, mid-air Spring Ball jumps, etc. You could get this information from "Horizontal speed" but it is obscured because it changes as you perform actions that affect the base speed/momentum (e.g. spin jump, break spin, mid-air morph), whereas the dash speed remains constant through all of that.

Dash speed values are referenced throughout the Map Rando logic pages; it's commonly useful in cross-room strats needing specific amounts of speed. I've worked on a lot of these, so for the past year I've spent probably the majority of my time in the Practice Hack with a Ram Watch set to dash speed. Using a Ram Watch works but can be a barrier for players trying to learn the strats or contribute strat videos. An InfoHUD mode should make it more accessible and easy to use.

A SuperHUD mode for this would also be useful so I'm hoping to follow up with that.