### PR TITLE
Force Big Boy room music to be correct prior to baby skip attempt

### DIFF
--- a/src/layout.asm
+++ b/src/layout.asm
@@ -453,6 +453,11 @@ hook_layout_asm_pants_to_pants:
     dw #$8000
     dw #layout_asm_pants_to_pants_scrolls
 
+; Big Boy Room right door
+org $83AA36
+hook_layout_asm_dusttorizo_door1:
+    dw #layout_asm_big_boy_music
+
 ; Tourian Escape 1 right door
 org $83AA96
 hook_layout_asm_motherbrain_door1:
@@ -2472,6 +2477,20 @@ layout_asm_tourianescape1:
     CMP #$0002 : BNE layout_asm_mbhp_done
     LDA !ram_door_source : ASL : TAX
     LDA portals_left_vanilla_table,X : CMP #$AAE0 : BEQ layout_asm_tourianescape1_remove_plm
+    RTS
+}
+
+layout_asm_big_boy_music:
+{
+    LDA !MUSIC_DATA : CMP #$0045 : BEQ .check_track
+    TDC : JSL !MUSIC_ROUTINE
+    LDA #$FF45 : JSL !MUSIC_ROUTINE
+
+  .check_track
+    LDA #$0006 : CMP !MUSIC_TRACK : BEQ .done
+    JSL !MUSIC_ROUTINE
+
+  .done
     RTS
 }
 

--- a/src/main.asm
+++ b/src/main.asm
@@ -17,7 +17,7 @@ lorom
 !VERSION_MAJOR = 2
 !VERSION_MINOR = 7
 !VERSION_BUILD = 3
-!VERSION_REV   = 0
+!VERSION_REV   = 1
 
 table ../resources/normal.tbl
 print ""

--- a/web/data/changelog.mdx
+++ b/web/data/changelog.mdx
@@ -25,6 +25,7 @@
 - Fix page navigation in SuperHUD menu (2.7.2.3)
 - Add category adjustment options, and also a few small category preset fixes (2.7.3)
 - Add toggle IGT/RTA and Boss HP controller shortcuts, and a couple bonk indicators (2.7.3)
+- Force Big Boy room music to be correct prior to baby skip attempt (2.7.3.1)
 
 # Version 2.6.x
 - Optimize kraid rock projectiles to reduce lag when Kraid rises (2.6.0)

--- a/web/data/config.json
+++ b/web/data/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Super Metroid Practice Hack",
-    "version": "2.7.3",
+    "version": "2.7.3.1",
     "variants": ["NTSC", "PAL"],
     "base": {
         "NTSC": {


### PR DESCRIPTION
An issue was found using custom door portals.  The two rooms prior to Big Boy room prepare boss music, but Big Boy room itself does not since Samus is free to re-enter Big Boy room afterwards and it would not make sense to have boss music.  However the baby skip cutscene does require the music track to be prepared or else the music sounds bad; it even crashed on someone's emulator (although it did not crash for me on console... but it did sound bad when getting grabbed by baby).  Anyway, fixing the music is both the right thing to do for practicing baby skip using custom portal and it should also avoid sound crashes.

It's worth noting that, while connecting custom door portal to the room prior to Big Boy room would avoid the crash, it's not a great solution.  Connecting a custom door portal to Big Boy room causes the map rando sped-up version of the hopper cutscene to play out, which could be useful for practicing things like bomb spread baby skip method for map rando, so there is a reason to set up the portal this way.  While I'm sure I tested this scenario in the past, I must have had the music turned off when testing.