### PR TITLE
Improved fix for preserving DP registers when opening/closing the menu

### DIFF
--- a/src/BRBmenu.asm
+++ b/src/BRBmenu.asm
@@ -431,7 +431,7 @@ brb_zsnes_splashscreen:
     ; Set up video mode
     %ai8()
     LDA #$80    ; screen off
-    STA $2100   ; brightness + screen enable register
+    STA $802100 ; brightness + screen enable register
     LDA #$03
     STA $2105   ; video mode 3, 8x8 tiles, 256 color BG1, 16 color BG2
     STZ $2106   ; noplanes, no mosaic, = Mosaic register
@@ -506,7 +506,7 @@ brb_zsnes_splashscreen:
     STA $420B   ; Start DMA transfer
 
     LDA #$0F    ; screen on, full brightness
-    STA $2100   ; brightness + screen enable register
+    STA $0F2100 ; brightness + screen enable register
 
     %a16()
     RTS
@@ -584,7 +584,7 @@ cm_transfer_brb_tileset:
 
     ; Load custom vram to normal location
     %a8()
-    LDA #$80 : STA $2100 ; enable forced blanking
+    LDA #$80 : STA $802100 ; enable forced blanking
     LDA #!DP_CurrentMenu : STA $210C
     LDA #$80 : STA $2115 ; word-access, incr by 1
     LDX #$4000 : STX $2116 ; VRAM address (8000 in vram)
@@ -594,7 +594,7 @@ cm_transfer_brb_tileset:
     LDA #$01 : STA $4300 ; word, normal increment (DMA MODE)
     LDA #$18 : STA $4301 ; destination (VRAM write)
     LDA #$01 : STA $420B ; initiate DMA (channel 1)
-    LDA #$0F : STA $2100 ; disable forced blanking
+    LDA #$0F : STA $0F2100 ; disable forced blanking
     PLP
     RTS
 }
@@ -666,19 +666,14 @@ cm_brb_scroll_BG3:
 
   .applyScrolls
     ; force blank and apply scrolls
-    %i8()
-    LDX #$80 : STX $2100
+    LDA !ram_cm_brb_scroll_Y : DEC : PHA
+    LDA !ram_cm_brb_scroll_X : PHA
 
-    LDA !ram_cm_brb_scroll_X
     %a8()
-    STA $2111 : XBA : STA $2111
-    %a16()
-
-    LDA !ram_cm_brb_scroll_Y : DEC
-    %a8()
-    STA $2112 : XBA : STA $2112
-
-    LDA #$0F : STA $2100
+    LDA #$80 : STA $802100
+    PLA : STA $2111 : PLA : STA $2111
+    PLA : STA $2112 : PLA : STA $2112
+    LDA #$0F : STA $0F2100
 
     PLP
     RTS

--- a/src/crash.asm
+++ b/src/crash.asm
@@ -191,7 +191,7 @@ CrashViewer:
     PHK : PLB
     %a8()
     STZ $420C
-    LDA #$80 : STA $002100  ; Force blank on, zero brightness
+    LDA #$80 : STA $802100  ; Force blank on, zero brightness
     LDA #$A1 : STA $4200  ; NMI, V-blank IRQ, and auto-joypad read on
     LDA #$09 : STA $2105  ; BG3 priority on, BG Mode 1
     LDA #$58 : STA $2109  ; BG3 address, 32x32 size
@@ -201,7 +201,7 @@ CrashViewer:
     LDA #$33 : STA $2131  ; Enable color math on backgrounds and OAM
     STZ $2111 : STZ $2111 ; BG3 X scroll, write twice
     STZ $2112 : STZ $2112 ; BG3 Y scroll, write twice
-    LDA #$0F : STA $002100  ; Force blank off, max brightness
+    LDA #$0F : STA $0F2100  ; Force blank off, max brightness
 
     %ai16()
     JSL crash_next_frame
@@ -945,7 +945,7 @@ crash_cgram_transfer:
 crash_toggle_bg:
 {
     %a8()
-    LDA #$80 : STA $002100 ; enable forced blanking
+    LDA #$80 : STA $802100 ; enable forced blanking
     LDA !ram_crash_bg : BEQ .enableBG
     ; disable BG1/2 and sprites on main/sub screen
     LDA #$04 : STA $212C : STA $212D
@@ -956,7 +956,7 @@ crash_toggle_bg:
     LDA #$17 : STA $212C : STA $212D
 
   .done
-    LDA #$0F : STA $002100 ; disable forced blanking
+    LDA #$0F : STA $0F2100 ; disable forced blanking
     LDA !ram_crash_bg : EOR #$01 : STA !ram_crash_bg
     %a16()
     RTS

--- a/src/cropmenu.asm
+++ b/src/cropmenu.asm
@@ -39,10 +39,10 @@ ccm_crop_tile:
 
 cm_crop_mode:
 {
-    PHP : %a16() : %i8()
-
+    PHP : %ai8()
     ; turn on forced blank
-    LDX #$80 : STX $2100
+    LDA #$80 : STA $802100
+    %a16()
 
     ; fix BG3 scroll offset
     LDX #$FF : STX $2112
@@ -72,7 +72,9 @@ cm_crop_mode:
 
   .drawingdone
     ; turn off forced blank
-    LDX #$0F : STX $2100
+    %a8()
+    LDA #$0F : STA $0F2100
+    %a16()
 
   .loop
     ; Make sure we don't read joysticks twice in the same frame
@@ -108,11 +110,11 @@ cm_crop_mode:
 
   .end
     ; restore BG3 scroll offset
-    LDA !REG_2112_BG3_Y
+    LDA !REG_2112_BG3_Y : PHA
     %ai8()
-    LDX #$80 : STX $2100
-    STA $2112 : XBA : STA $2112
-    LDX #$0F : STX $2100
+    LDA #$80 : STA $802100
+    PLA : STA $2112 : PLA : STA $2112
+    LDA #$0F : STA $0F2100
 
     PLP
     RTL

--- a/src/main.asm
+++ b/src/main.asm
@@ -17,7 +17,7 @@ lorom
 !VERSION_MAJOR = 2
 !VERSION_MINOR = 7
 !VERSION_BUILD = 4
-!VERSION_REV   = 6
+!VERSION_REV   = 7
 
 table ../resources/normal.tbl
 print ""

--- a/src/menu.asm
+++ b/src/menu.asm
@@ -148,10 +148,10 @@ cm_init:
     ; Setup registers
     %a8()
     STZ $420C
-    LDA #$80 : STA $2100 ; enable forced blanking
+    LDA #$80 : STA $802100 ; enable forced blanking
     LDA #$A1 : STA $4200 ; enable NMI, v-IRQ, and auto-joy read
     LDA #$09 : STA $2105 ; BG Mode 1, enable BG3 priority
-    LDA #$0F : STA $2100 ; disable forced blanking
+    LDA #$0F : STA $0F2100 ; disable forced blanking
     %ai16()
 
     ; Preserve DP registers
@@ -329,7 +329,7 @@ cm_transfer_custom_tileset:
 
     ; Load custom vram to normal BG3 location
     %a8()
-    LDA #$80 : STA $2100 ; enable forced blanking
+    LDA #$80 : STA $802100 ; enable forced blanking
     LDA #$04 : STA $210C ; BG3 starts at $4000 (8000 in vram)
     LDA #$80 : STA $2115 ; word-access, incr by 1
     LDX #$4000 : STX $2116 ; VRAM address (8000 in vram)
@@ -339,14 +339,14 @@ cm_transfer_custom_tileset:
     LDA #$01 : STA $4300 ; word, normal increment (DMA MODE)
     LDA #$18 : STA $4301 ; destination (VRAM write)
     LDA #$01 : STA $420B ; initiate DMA (channel 1)
-    LDA #$0F : STA $2100 ; disable forced blanking
+    LDA #$0F : STA $0F2100 ; disable forced blanking
     PLP
     RTL
 
   .kraid_vram
     ; Load custom vram to kraid BG3 location
     %a8()
-    LDA #$80 : STA $2100 ; enable forced blanking
+    LDA #$80 : STA $802100 ; enable forced blanking
     LDA #$02 : STA $210C ; BG3 starts at $2000 (4000 in vram)
     LDA #$80 : STA $2115 ; word-access, incr by 1
     LDX #$2000 : STX $2116 ; VRAM address (4000 in vram)
@@ -356,7 +356,7 @@ cm_transfer_custom_tileset:
     LDA #$01 : STA $4300 ; word, normal increment (DMA MODE)
     LDA #$18 : STA $4301 ; destination (VRAM write)
     LDA #$01 : STA $420B ; initiate DMA (channel 1)
-    LDA #$0F : STA $2100 ; disable forced blanking
+    LDA #$0F : STA $0F2100 ; disable forced blanking
     PLP
     RTL
 }
@@ -384,7 +384,7 @@ endif
 
   .normal_vram
     ; Load in normal vram to normal BG3 location
-    LDA #$80 : STA $2100 ; enable forced blanking
+    LDA #$80 : STA $802100 ; enable forced blanking
     LDA #$04 : STA $210C ; BG3 starts at $4000 (8000 in vram)
     LDA #$80 : STA $2115 ; word-access, incr by 1
     LDX #$4000 : STX $2116 ; VRAM address (8000 in vram)
@@ -394,7 +394,7 @@ endif
     LDA #$01 : STA $4300 ; word, normal increment (DMA MODE)
     LDA #$18 : STA $4301 ; destination (VRAM write)
     LDA #$01 : STA $420B ; initiate DMA (channel 1)
-    LDA #$0F : STA $2100 ; disable forced blanking
+    LDA #$0F : STA $0F2100 ; disable forced blanking
     PLP
     RTL
 
@@ -406,7 +406,7 @@ else
 endif
 
     ; Load in normal vram to kraid BG3 location
-    LDA #$80 : STA $2100 ; enable forced blanking
+    LDA #$80 : STA $802100 ; enable forced blanking
     LDA #$02 : STA $210C ; BG3 starts at $2000 (4000 in vram)
     LDA #$80 : STA $2115 ; word-access, incr by 1
     LDX #$2000 : STX $2116 ; VRAM address (4000 in vram)
@@ -416,7 +416,7 @@ endif
     LDA #$01 : STA $4300 ; word, normal increment (DMA MODE)
     LDA #$18 : STA $4301 ; destination (VRAM write)
     LDA #$01 : STA $420B ; initiate DMA (channel 1)
-    LDA #$0F : STA $2100 ; disable forced blanking
+    LDA #$0F : STA $0F2100 ; disable forced blanking
     PLP
     RTL
 
@@ -424,7 +424,7 @@ if !FEATURE_VANILLAHUD
 else
   .minimap_vram
     ; Load in minimap vram to normal BG3 location
-    LDA #$80 : STA $2100 ; enable forced blanking
+    LDA #$80 : STA $802100 ; enable forced blanking
     LDA #$04 : STA $210C ; BG3 starts at $4000 (8000 in vram)
     LDA #$80 : STA $2115 ; word-access, incr by 1
     LDX #$4000 : STX $2116 ; VRAM address (8000 in vram)
@@ -434,13 +434,13 @@ else
     LDA #$01 : STA $4300 ; word, normal increment (DMA MODE)
     LDA #$18 : STA $4301 ; destination (VRAM write)
     LDA #$01 : STA $420B ; initiate DMA (channel 1)
-    LDA #$0F : STA $2100 ; disable forced blanking
+    LDA #$0F : STA $0F2100 ; disable forced blanking
     PLP
     RTL
 
   .kraid_minimap_vram
     ; Load in minimap vram to kraid BG3 location
-    LDA #$80 : STA $2100 ; enable forced blanking
+    LDA #$80 : STA $802100 ; enable forced blanking
     LDA #$02 : STA $210C ; BG3 starts at $2000 (4000 in vram)
     LDA #$80 : STA $2115 ; word-access, incr by 1
     LDX #$2000 : STX $2116 ; VRAM address (4000 in vram)
@@ -450,7 +450,7 @@ else
     LDA #$01 : STA $4300 ; word, normal increment (DMA MODE)
     LDA #$18 : STA $4301 ; destination (VRAM write)
     LDA #$01 : STA $420B ; initiate DMA (channel 1)
-    LDA #$0F : STA $2100 ; disable forced blanking
+    LDA #$0F : STA $0F2100 ; disable forced blanking
     PLP
     RTL
 endif

--- a/src/menu.asm
+++ b/src/menu.asm
@@ -19,17 +19,15 @@ incsrc mainmenu.asm
 %startfree(85)
 
 initialize_ppu_long:
-    PHP : %a16()
     LDA $7E33EA : STA !ram_cgram_cache+$2E
-    PLP
     JSR $8143
+    ; cm_transfer_custom_tileset will call %ai16()
     RTL
 
 restore_ppu_long:
     JSR $861A
-    PHP : %a16()
+    %ai16()
     LDA !ram_cgram_cache+$2E : STA $7E33EA
-    PLP
     RTL
 
 play_music_long:
@@ -150,11 +148,17 @@ cm_init:
     ; Setup registers
     %a8()
     STZ $420C
-    LDA #$80 : STA $802100 ; enable forced blanking
+    LDA #$80 : STA $2100 ; enable forced blanking
     LDA #$A1 : STA $4200 ; enable NMI, v-IRQ, and auto-joy read
     LDA #$09 : STA $2105 ; BG Mode 1, enable BG3 priority
-    LDA #$0F : STA $0F2100 ; disable forced blanking
-    %a16()
+    LDA #$0F : STA $2100 ; disable forced blanking
+    %ai16()
+
+    ; Preserve DP registers
+    PHB : LDX #$0000                  ; X = Source
+    LDY.w #!DP_REGISTER_BACKUP_START  ; Y = Destination
+    LDA.w #!DP_REGISTER_BACKUP_SIZE-1 ; A = Size-1
+    MVN $7E7E : PLB                   ; srcBank, destBank
 
     ; Preserve timers while menu is active
     LDA !ram_realtime_room : STA !ram_cm_preserved_timers
@@ -223,6 +227,12 @@ endif
     JSL init_physics_ram
     JSL GameLoopExtras ; check if game_loop_extras needs to be disabled
 
+    ; Restore DP registers
+    PHB : LDY #$0000                  ; Y = Destination
+    LDX.w #!DP_REGISTER_BACKUP_START  ; X = Source
+    LDA.w #!DP_REGISTER_BACKUP_SIZE-1 ; A = Size-1
+    MVN $7E7E : PLB                   ; srcBank, destBank
+
     ; Restore timers
     LDA !ram_cm_preserved_timers : STA !ram_realtime_room
     LDA !ram_cm_preserved_timers+2 : STA !ram_seg_rt_frames
@@ -232,7 +242,6 @@ endif
     JSL restore_ppu_long ; Restore PPU
 
     ; skip sound effects if not gameplay ($7-13 allowed)
-    %ai16()
     LDA !GAMEMODE : CMP #$0006 : BMI .skipSFX
     CMP #$0014 : BPL .skipSFX
     JSL $82BE2F ; Queue Samus movement sound effects
@@ -241,7 +250,7 @@ endif
     JSL play_music_long ; Play 2 lag frames of music and sound effects
     JSL maybe_trigger_pause_long ; Maybe trigger pause screen or return save confirmation selection
 
-    ; Restore timers
+    ; Restore timers again
     LDA !ram_cm_preserved_timers : STA !ram_realtime_room
     LDA !ram_cm_preserved_timers+$2 : STA !ram_seg_rt_frames
     LDA !ram_cm_preserved_timers+$4 : STA !ram_seg_rt_seconds
@@ -450,28 +459,22 @@ endif
 cm_transfer_custom_cgram:
 {
     %ai16()
-    ; backup DB registers (also sets bank to 7E)
-    PHB : LDX #$0000                  ; X = Source
-    LDY.w #!DP_REGISTER_BACKUP_START  ; Y = Destination
-    LDA.w #!DP_REGISTER_BACKUP_SIZE-1 ; A = Size-1
-    MVN $7E7E                         ; srcBank, destBank
 
     ; backup gameplay palettes
-    LDA $C00A : STA !ram_cgram_cache
-    LDA $C00E : STA !ram_cgram_cache+$02
-    LDA $C012 : STA !ram_cgram_cache+$04
-    LDA $C014 : STA !ram_cgram_cache+$06
-    LDA $C016 : STA !ram_cgram_cache+$08
-    LDA $C01A : STA !ram_cgram_cache+$0A
-    LDA $C01C : STA !ram_cgram_cache+$0C
-    LDA $C01E : STA !ram_cgram_cache+$0E
-    LDA $C032 : STA !ram_cgram_cache+$10
-    LDA $C034 : STA !ram_cgram_cache+$12
-    LDA $C036 : STA !ram_cgram_cache+$14
-    LDA $C03A : STA !ram_cgram_cache+$16
-    LDA $C03C : STA !ram_cgram_cache+$18
-    LDA $C03E : STA !ram_cgram_cache+$1A
-    PLB
+    LDA $7EC00A : STA !ram_cgram_cache
+    LDA $7EC00E : STA !ram_cgram_cache+$02
+    LDA $7EC012 : STA !ram_cgram_cache+$04
+    LDA $7EC014 : STA !ram_cgram_cache+$06
+    LDA $7EC016 : STA !ram_cgram_cache+$08
+    LDA $7EC01A : STA !ram_cgram_cache+$0A
+    LDA $7EC01C : STA !ram_cgram_cache+$0C
+    LDA $7EC01E : STA !ram_cgram_cache+$0E
+    LDA $7EC032 : STA !ram_cgram_cache+$10
+    LDA $7EC034 : STA !ram_cgram_cache+$12
+    LDA $7EC036 : STA !ram_cgram_cache+$14
+    LDA $7EC03A : STA !ram_cgram_cache+$16
+    LDA $7EC03C : STA !ram_cgram_cache+$18
+    LDA $7EC03E : STA !ram_cgram_cache+$1A
 
     JSL PrepMenuPalette
 
@@ -489,40 +492,30 @@ cm_transfer_custom_cgram:
     LDA !ram_cm_palette_numseloutline : STA $7EC03A
     LDA !ram_cm_palette_numsel : STA $7EC03C
 
-    JSL transfer_cgram_long
-    %ai16()
-    RTL
+    JML transfer_cgram_long
 }
 
 cm_transfer_original_cgram:
 {
-    PHP : %ai16()
-    ; restore DB registers (also sets bank to 7E)
-    PHB : LDY #$0000                  ; Y = Destination
-    LDX.w #!DP_REGISTER_BACKUP_START  ; X = Source
-    LDA.w #!DP_REGISTER_BACKUP_SIZE-1 ; A = Size-1
-    MVN $7E7E                         ; srcBank, destBank
+    %ai16()
 
     ; restore gameplay palettes
-    LDA !ram_cgram_cache : STA $C00A
-    LDA !ram_cgram_cache+$02 : STA $C00E
-    LDA !ram_cgram_cache+$04 : STA $C012
-    LDA !ram_cgram_cache+$06 : STA $C014
-    LDA !ram_cgram_cache+$08 : STA $C016
-    LDA !ram_cgram_cache+$0A : STA $C01A
-    LDA !ram_cgram_cache+$0C : STA $C01C
-    LDA !ram_cgram_cache+$0E : STA $C01E
-    LDA !ram_cgram_cache+$10 : STA $C032
-    LDA !ram_cgram_cache+$12 : STA $C034
-    LDA !ram_cgram_cache+$14 : STA $C036
-    LDA !ram_cgram_cache+$16 : STA $C03A
-    LDA !ram_cgram_cache+$18 : STA $C03C
-    LDA !ram_cgram_cache+$1A : STA $C03E
-    PLB
+    LDA !ram_cgram_cache : STA $7EC00A
+    LDA !ram_cgram_cache+$02 : STA $7EC00E
+    LDA !ram_cgram_cache+$04 : STA $7EC012
+    LDA !ram_cgram_cache+$06 : STA $7EC014
+    LDA !ram_cgram_cache+$08 : STA $7EC016
+    LDA !ram_cgram_cache+$0A : STA $7EC01A
+    LDA !ram_cgram_cache+$0C : STA $7EC01C
+    LDA !ram_cgram_cache+$0E : STA $7EC01E
+    LDA !ram_cgram_cache+$10 : STA $7EC032
+    LDA !ram_cgram_cache+$12 : STA $7EC034
+    LDA !ram_cgram_cache+$14 : STA $7EC036
+    LDA !ram_cgram_cache+$16 : STA $7EC03A
+    LDA !ram_cgram_cache+$18 : STA $7EC03C
+    LDA !ram_cgram_cache+$1A : STA $7EC03E
 
-    JSL transfer_cgram_long
-    PLP
-    RTL
+    JML transfer_cgram_long
 }
 
 cm_draw:

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -865,7 +865,7 @@ preset_clear_BG2_tilemap:
 
     ; Upload BG2 Tilemap
     %a8()
-    LDA #$80 : STA $2100 ; enable forced blanking
+    LDA #$80 : STA $802100 ; enable forced blanking
     LDA #$04 : STA $210C ; BG2 starts at $4000 (8000 in vram)
     LDA #$80 : STA $2115 ; word-access, incr by 1
     LDX #$4800 : STX $2116 ; VRAM address (8000 in vram)
@@ -875,7 +875,7 @@ preset_clear_BG2_tilemap:
     LDA #$01 : STA $4300 ; word, normal increment (DMA MODE)
     LDA #$18 : STA $4301 ; destination (VRAM write)
     LDA #$01 : STA $420B ; initiate DMA (channel 1)
-    LDA #$0F : STA $2100 ; disable forced blanking
+    LDA #$0F : STA $0F2100 ; disable forced blanking
     PLP
     RTL
 }
@@ -1105,10 +1105,12 @@ preset_bg_offsets:
 transfer_cgram_long:
 {
     PHP
-    %a16() : %i8()
-    LDX #$80 : STX $2100 ; forced blanking
+    %ai8()
+    LDA #$80 : STA $802100 ; forced blanking
+    %a16()
     JSR $933A
-    LDX #$0F : STX $2100
+    %a8()
+    LDA #$0F : STA $0F2100
     PLP
     RTL
 }

--- a/src/ramwatchmenu.asm
+++ b/src/ramwatchmenu.asm
@@ -555,10 +555,10 @@ ramwatch_common_anyglitched_090F:
     %cm_jsl("090F Layer 1 SubX     --F-", action_select_common_address, #!LAYER1_SUB_X)
 
 ramwatch_common_anyglitched_0913:
-    %cm_jsl("0913 Layer 1 SubY     --00", action_select_common_address, #!LAYER1_SUB_Y)
+    %cm_jsl("0913 Layer 1 SubY     --0-", action_select_common_address, #!LAYER1_SUB_Y)
 
 ramwatch_common_anyglitched_0C5E:
-    %cm_jsl("0C5E Bomb One Geemer  FF--", action_select_common_address, #!SAMUS_BOMB_INSTRUCTION_TIMER)
+    %cm_jsl("0C5E Bomb One Geemer  F---", action_select_common_address, #!SAMUS_BOMB_INSTRUCTION_TIMER)
 
 ramwatch_common_anyglitched_0E20:
     %cm_jsl("0E20 5olD Geemer Side F---", action_select_common_address, #$0E20)

--- a/src/save.asm
+++ b/src/save.asm
@@ -246,7 +246,7 @@ register_restore_return:
 {
     %a8()
     LDA !REG_4200_NMI : STA $4200
-    LDA #$0F : STA $13 : STA $2100
+    LDA #$0F : STA $13 : STA $0F2100
     RTL
 }
 

--- a/src/tinystates.asm
+++ b/src/tinystates.asm
@@ -62,7 +62,7 @@ pre_load_state:
   .done
     ; Force blank and disable NMI
     %a8()
-    LDA #$80 : STA $2100
+    LDA #$80 : STA $802100
     LDA #$00 : STA $4200
     %ai16()
 
@@ -290,7 +290,7 @@ register_restore_return:
 {
     %a8()
     LDA !REG_4200_NMI : STA $4200
-    LDA #$0F : STA $13 : STA !REG_2100_BRIGHTNESS : STA $2100
+    LDA #$0F : STA $13 : STA !REG_2100_BRIGHTNESS : STA $0F2100
     RTL
 }
 

--- a/web/data/changelog.mdx
+++ b/web/data/changelog.mdx
@@ -38,6 +38,7 @@
 - Make OOB Tile Viewer compatible (2.7.4.4)
 - Add any% glitched RAM addresses (2.7.4.5)
 - Cross-referenced any% glitched RAM addresses with the disassembly (2.7.4.6)
+- Improved fix for preserving DP registers when opening/closing the menu (2.7.4.7)
 
 # Version 2.6.x
 - Optimize kraid rock projectiles to reduce lag when Kraid rises (2.6.0)

--- a/web/data/config.json
+++ b/web/data/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Super Metroid Practice Hack",
-    "version": "2.7.4.6",
+    "version": "2.7.4.7",
     "variants": ["NTSC", "PAL"],
     "base": {
         "NTSC": {


### PR DESCRIPTION
I don't think we want to restore DP registers twice like we do for the timer variables.  It is possible there is a specific DP register we should restore a second time but I'd like to know why rather than blanket restore.  The timer variables are restored twice because we let a few frames execute before returning control to the user.  We wanted the timer variables to be reasonable when running those few frames, but we also don't want to count those frames when computing room times later.

We definitely should restore DP registers later than I was doing in my earlier solution to group it with cgram, since after restoring cgram we were calling methods like initialize HUD that we would not call in the middle of a room normally.  Whatever methods like that are doing with DP registers, we want to undo that to provide a more realistic memory state.

While doing this I also cleaned up some unnecessary PHP/PLP calls, where we were calling %ai16() later on anyway.

This does fix the issue I was having with $0026 and $0028 registers not being maintained.  Planning to release this later today; let me know if you have concerns.