### PR TITLE
Improve OOB tile viewer

### DIFF
--- a/src/defines.asm
+++ b/src/defines.asm
@@ -1479,21 +1479,22 @@ endif
 ; Each botwoon pattern can be #$00 (off), #$01, #$09, #$11, #$19
 ; (except hidden pattern cannot be #$19)
 ; This corresponds to just three bits of information
-; For efficiency this information can be overlapped,
+; For efficiency this information can be overlapped
+; and is done for the hidden and second patterns,
 ; allowing for the spit value (#$00, #$04, #$08) to be included
-; and also the after spit value in the most and least significant bits
-!BOTWOON_RNG_FIRST_MASK             = #$0032 ; #$0019 << 1
-!BOTWOON_RNG_FIRST_INVERTED         = #$FFCD
-!BOTWOON_RNG_FIRST_ENABLED          = #$0002
-!BOTWOON_RNG_FIRST_VALUE            = #$0030
-!BOTWOON_RNG_HIDDEN_MASK            = #$0C80 ; #$1900 >> 1
-!BOTWOON_RNG_HIDDEN_INVERTED        = #$F37F
-!BOTWOON_RNG_HIDDEN_ENABLED         = #$0080
-!BOTWOON_RNG_HIDDEN_VALUE           = #$0C00
-!BOTWOON_RNG_SECOND_MASK            = #$3200 ; #$1900 << 1
-!BOTWOON_RNG_SECOND_INVERTED        = #$CDFF
-!BOTWOON_RNG_SECOND_ENABLED         = #$0200
-!BOTWOON_RNG_SECOND_VALUE           = #$3000
+; and also the after spit value in the most and least significant bits,
+; and a bit for each of the four first patterns toggled individually
+!BOTWOON_RNG_FIRST_MASK             = #$00F0
+!BOTWOON_RNG_FIRST_INVERTED         = #$FF0F
+!BOTWOON_RNG_HIDDEN_MASK            = #$1900 ; $19 << 8
+!BOTWOON_RNG_HIDDEN_INVERTED        = #$E6FF
+!BOTWOON_RNG_HIDDEN_ENABLED         = #$0100
+!BOTWOON_RNG_HIDDEN_VALUE           = #$1800
+!BOTWOON_RNG_SECOND_MASK            = #$6400 ; $19 << 10
+!BOTWOON_RNG_SECOND_INVERTED        = #$9BFF
+!BOTWOON_RNG_SECOND_ENABLED         = #$0400
+!BOTWOON_RNG_SECOND_VALUE           = #$6000
+!BOTWOON_RNG_ALL_PATTERN_MASK       = #$7DF0
 !BOTWOON_RNG_SPIT_MASK              = #$000C
 !BOTWOON_RNG_SPIT_INVERTED          = #$FFF3
 !BOTWOON_RNG_AFTER_SPIT_ENABLED     = #$8000

--- a/src/defines.asm
+++ b/src/defines.asm
@@ -475,7 +475,7 @@
 ; SRAM
 ; -----
 
-!SRAM_VERSION = #$001C
+!SRAM_VERSION = #$001D
 
 !SRAM_START = $702000
 !SRAM_SIZE = #$1000
@@ -559,6 +559,7 @@
 !sram_fast_pause = !SRAM_START+$A4
 !sram_bonk_indicators = !SRAM_START+$A6
 !sram_speed_booster_physics = !SRAM_START+$A8
+!sram_fast_teleport = !SRAM_START+$AA
 
 ; ^ FREE SPACE ^ up to +$EC
 

--- a/src/enemy_rng.asm
+++ b/src/enemy_rng.asm
@@ -165,15 +165,22 @@ endif
 
 init_botwoon_rng:
 {
-    LDA !ram_botwoon_rng : AND !BOTWOON_RNG_SPIT_INVERTED : STA !eram_botwoon_all_pattern_rng
-    AND !BOTWOON_RNG_FIRST_MASK : LSR : STA !eram_botwoon_first_rng
+    LDA !ram_botwoon_rng : AND !BOTWOON_RNG_ALL_PATTERN_MASK : STA !eram_botwoon_all_pattern_rng
+    AND !BOTWOON_RNG_FIRST_MASK : CMP !BOTWOON_RNG_FIRST_MASK : BEQ .invalid
+    STA !eram_botwoon_first_rng : LSR #4 : ORA !eram_botwoon_first_rng
+  .set_first
+    STA !eram_botwoon_first_rng
     LDA !ram_botwoon_rng : AND !BOTWOON_RNG_HIDDEN_MASK
-    ASL : XBA : STA !eram_botwoon_hidden_rng
+    XBA : STA !eram_botwoon_hidden_rng
     LDA !ram_botwoon_rng : AND !BOTWOON_RNG_SECOND_MASK
-    LSR : XBA : STA !eram_botwoon_second_rng
+    LSR #2 : XBA : STA !eram_botwoon_second_rng
     LDA !ram_botwoon_rng : AND !BOTWOON_RNG_SPIT_MASK : STA !eram_botwoon_spit_rng
     LDA !ram_botwoon_rng : AND !BOTWOON_RNG_AFTER_SPIT_MASK : STA !eram_botwoon_after_spit_rng
     RTL
+
+  .invalid
+    TDC
+    BRA .set_first
 }
 
 ; Vanilla main AI routine, just migrated
@@ -565,7 +572,7 @@ hook_phantoon_init:
     PHP ; push 1
     PLA ; pop 2 (for a total of 3 bytes popped)
 
-    ; start boss music & fade-in animation
+    ; start boss music and fade-in animation
 if !FEATURE_PAL
     JML $A7D543
 else
@@ -599,7 +606,7 @@ init_phantoon_rng:
 }
 
 
-; Table of Phantoon pattern durations & directions
+; Table of Phantoon pattern durations and directions
 ; bit 0 is direction, remaining bits are duration
 ; Note that later entries in the table will tend to occur slightly more often.
 phan_pattern_table:
@@ -853,6 +860,20 @@ endif
     RTL
 }
 
+
+; Table of botwoon patterns
+; Note that later entries in the table will tend to occur slightly more often.
+botwoon_pattern_table:
+    dw $0019 ; left
+    dw $0011 ; right
+    dw $0009 ; top
+    dw $0001 ; bottom
+    dw $0019 ; left
+    dw $0011 ; right
+    dw $0009 ; top
+    dw $0001 ; bottom
+
+
 hook_botwoon_move:
 {
     LDA !eram_botwoon_all_pattern_rng : BEQ .no_manip_maybe_first_roll
@@ -867,17 +888,6 @@ hook_botwoon_move:
     JSL $808111
     ; return chosen pattern
     LDA !eram_botwoon_second_rng
-    RTL
-
-  .first_round
-    ; check if first round pattern fixed
-    LDA !eram_botwoon_first_rng : BEQ .no_manip_maybe_first_roll
-    ; preserve number of RNG calls in the frame
-    JSL $808111
-    ; mark first round complete
-    STZ !eram_botwoon_first_roll
-    ; return chosen pattern
-    LDA !eram_botwoon_first_rng
     RTL
 
   .hidden
@@ -895,6 +905,48 @@ hook_botwoon_move:
   .no_manip
     ; return random pattern
     JML $808111
+
+  .first_round
+    ; check if first round pattern fixed
+    LDA !eram_botwoon_first_rng : BEQ .no_manip_maybe_first_roll
+
+    PHX     ; push enemy index
+    PHA     ; push pattern mask
+    ; mark first round complete
+    STZ !eram_botwoon_first_roll
+
+    ; get random number in range 0-7
+    JSL $808111
+    AND #$0007 : TAX
+
+    ; play a game of eeny-meeny-miny-moe with the enabled patterns
+    ; X = number of enabled patterns to find before stopping
+    ; Y = index in botwoon_pattern_table of pattern currently being checked
+    ; A = bitmask of enabled patterns
+  .reload
+    LDA $01,S ; reload pattern mask
+    LDY #$0008  ; number of patterns (decremented immediately to index of last pattern)
+
+  .loop
+    DEY
+    LSR : BCS .skip
+
+    ; Pattern index Y is enabled
+    DEX : BMI .done ; is this the last one?
+    BRA .loop   ; no, keep looping
+
+  .skip
+    ; Pattern Y is not enabled, try the next pattern
+    BEQ .reload ; if we've tried all the patterns, start over
+    BRA .loop
+
+  .done
+    ; We've found the pattern to use
+    PLA ; we don't need the pattern mask anymore
+    TYA : ASL : TAX
+    LDA.l botwoon_pattern_table,X
+    PLX ; pop enemy index
+    RTL
 }
 
 hook_botwoon_spit:

--- a/src/enemy_rng.asm
+++ b/src/enemy_rng.asm
@@ -182,7 +182,13 @@ init_botwoon_rng:
     TDC
     BRA .set_first
 }
+%warnpc($B396C6, $B396D6)
 
+if !FEATURE_PAL
+org $B3970F
+else
+org $B396FF
+endif
 ; Vanilla main AI routine, just migrated
 botwoon_vanilla_main_ai:
 {
@@ -200,7 +206,7 @@ else
 endif
     RTL
 }
-%warnpc($B396C6, $B396D6)
+%warnpc($B3971B, $B3972B)
 
 if !FEATURE_PAL
 org $B398D1

--- a/src/gamemenu.asm
+++ b/src/gamemenu.asm
@@ -18,6 +18,7 @@ GameMenu:
     dw #game_fast_doors_toggle
     dw #game_fast_elevators
     dw #game_fast_pause
+    dw #game_fast_teleport
     dw #$FFFF
     dw #game_goto_debug
     dw #$FFFF
@@ -123,6 +124,9 @@ game_fast_elevators:
 
 game_fast_pause:
     %cm_toggle("Fast Pause", !sram_fast_pause, #$01, #0)
+
+game_fast_teleport:
+    %cm_toggle("Fast Teleport", !sram_fast_teleport, #$01, #0)
 
 game_goto_debug:
     %cm_submenu("Debug Settings", #DebugMenu)

--- a/src/init.asm
+++ b/src/init.asm
@@ -82,12 +82,12 @@ init_factory_reset:
 
 init_non_zero_persistent_wram:
 {
-    LDA #!ENEMY_HP : STA.w !ram_watch_left
-    LDA #!SAMUS_HP : STA.w !ram_watch_right
-    LDA #$007E : STA.w !ram_watch_bank
-    LDA !sram_seed_X : STA.w !ram_seed_X
-    LDA !sram_seed_Y : STA.w !ram_seed_Y
-    LDA #$8000 : STA.w !ram_cm_gmode
+    LDA #!ENEMY_HP : STA !ram_watch_left
+    LDA #!SAMUS_HP : STA !ram_watch_right
+    LDA #$007E : STA !ram_watch_bank
+    LDA !sram_seed_X : STA !ram_seed_X
+    LDA !sram_seed_Y : STA !ram_seed_Y
+    LDA #$8000 : STA !ram_cm_gmode
     RTS
 }
 

--- a/src/init.asm
+++ b/src/init.asm
@@ -121,6 +121,7 @@ init_sram_routine_table:
     dw init_sram_upgrade_19to1A
     dw init_sram_upgrade_1Ato1B
     dw init_sram_upgrade_1Bto1C
+    dw init_sram_upgrade_1Cto1D
 
 init_sram:
 {
@@ -257,6 +258,9 @@ endif
     STA !sram_bonk_indicators
     STA !sram_speed_booster_physics
     STA !sram_streamer_name
+
+  .upgrade_1Cto1D
+    TDC : INC : STA !sram_fast_teleport
 
     LDA !SRAM_VERSION : STA !sram_initialized
     RTS

--- a/src/main.asm
+++ b/src/main.asm
@@ -17,7 +17,7 @@ lorom
 !VERSION_MAJOR = 2
 !VERSION_MINOR = 7
 !VERSION_BUILD = 4
-!VERSION_REV   = 7
+!VERSION_REV   = 8
 
 table ../resources/normal.tbl
 print ""

--- a/src/main.asm
+++ b/src/main.asm
@@ -17,7 +17,7 @@ lorom
 !VERSION_MAJOR = 2
 !VERSION_MINOR = 7
 !VERSION_BUILD = 4
-!VERSION_REV   = 10
+!VERSION_REV   = 11
 
 table ../resources/normal.tbl
 print ""

--- a/src/main.asm
+++ b/src/main.asm
@@ -17,7 +17,7 @@ lorom
 !VERSION_MAJOR = 2
 !VERSION_MINOR = 7
 !VERSION_BUILD = 4
-!VERSION_REV   = 8
+!VERSION_REV   = 10
 
 table ../resources/normal.tbl
 print ""

--- a/src/main.asm
+++ b/src/main.asm
@@ -16,8 +16,8 @@ lorom
 
 !VERSION_MAJOR = 2
 !VERSION_MINOR = 7
-!VERSION_BUILD = 4
-!VERSION_REV   = 11
+!VERSION_BUILD = 5
+!VERSION_REV   = 0
 
 table ../resources/normal.tbl
 print ""

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -3757,18 +3757,18 @@ rng_ridley_tail:
 
 rng_prepare_botwoon_menu:
 {
-    TDC : STA !ram_cm_botwoon_first_rng
-    STA !ram_cm_botwoon_hidden_rng : STA !ram_cm_botwoon_second_rng
-    LDA !ram_botwoon_rng : BIT !BOTWOON_RNG_FIRST_ENABLED : BEQ .botwoonHidden
-    AND !BOTWOON_RNG_FIRST_VALUE : LSR #4 : INC
-    STA !ram_cm_botwoon_first_rng : LDA !ram_botwoon_rng
-  .botwoonHidden
-    BIT !BOTWOON_RNG_HIDDEN_ENABLED : BEQ .botwoonSecond
-    AND !BOTWOON_RNG_HIDDEN_VALUE : XBA : LSR #2 : INC
+    LDA !ram_botwoon_rng : AND !BOTWOON_RNG_FIRST_MASK
+    CMP !BOTWOON_RNG_FIRST_MASK : BNE .botwoonFirst
+    AND !BOTWOON_RNG_FIRST_INVERTED : STA !ram_botwoon_rng
+  .botwoonFirst
+    JSL rng_botwoon_set_first
+    TDC : STA !ram_cm_botwoon_hidden_rng : STA !ram_cm_botwoon_second_rng
+    LDA !ram_botwoon_rng : BIT !BOTWOON_RNG_HIDDEN_ENABLED : BEQ .botwoonSecond
+    AND !BOTWOON_RNG_HIDDEN_VALUE : XBA : LSR #3 : INC
     STA !ram_cm_botwoon_hidden_rng : LDA !ram_botwoon_rng
   .botwoonSecond
     BIT !BOTWOON_RNG_SECOND_ENABLED : BEQ .botwoonSpit
-    AND !BOTWOON_RNG_SECOND_VALUE : XBA : LSR #4 : INC
+    AND !BOTWOON_RNG_SECOND_VALUE : XBA : ASL #3 : XBA : INC
     STA !ram_cm_botwoon_second_rng : LDA !ram_botwoon_rng
   .botwoonSpit
     AND !BOTWOON_RNG_SPIT_MASK : LSR #2 : STA !ram_cm_botwoon_spit_rng
@@ -3783,6 +3783,11 @@ rng_prepare_botwoon_menu:
 
 RngBotwoonMenu:
     dw #rng_botwoon_first
+    dw #rng_botwoon_first_bottom
+    dw #rng_botwoon_first_top
+    dw #rng_botwoon_first_right
+    dw #rng_botwoon_first_left
+    dw #$FFFF
     dw #rng_botwoon_hidden
     dw #rng_botwoon_second
     dw #rng_botwoon_spit
@@ -3800,19 +3805,60 @@ rng_botwoon_first:
     db #$28, "  LT    TOP", #$FF
     db #$28, "  LR  RIGHT", #$FF
     db #$28, "  LL   LEFT", #$FF
+    db #$28, " NOT BOTTOM", #$FF
+    db #$28, " NOT    TOP", #$FF
+    db #$28, " NOT  RIGHT", #$FF
+    db #$28, " NOT   LEFT", #$FF
+    db #$28, " BOTTOM TOP", #$FF
+    db #$28, "BOTTOMRIGHT", #$FF
+    db #$28, "BOTTOM LEFT", #$FF
+    db #$28, "  TOP RIGHT", #$FF
+    db #$28, "   TOP LEFT", #$FF
+    db #$28, " RIGHT LEFT", #$FF
+    db #$28, "     CUSTOM", #$FF
     db #$FF
   .routine
+    ASL : TAX
     LDA !ram_botwoon_rng : AND !BOTWOON_RNG_FIRST_INVERTED
     STA !ram_botwoon_rng
-    LDA !ram_cm_botwoon_first_rng : BEQ .checkRoom
-    ; possible values are $01, $09, $11, $19
-    DEC : ASL #3 : INC : ASL
+    LDA.l rng_botwoon_first_table,X
     ORA !ram_botwoon_rng : STA !ram_botwoon_rng
   .checkRoom
     LDA !ROOM_ID : CMP.w #ROOM_BotwoonRoom : BNE .done
     JML init_botwoon_rng
   .done
     RTL
+
+rng_botwoon_first_table:
+    dw #$0000, #$00E0, #$00D0, #$00B0, #$0070, #$0010, #$0020, #$0040
+    dw #$0080, #$00C0, #$00A0, #$0060, #$0090, #$0050, #$0030, #$00F0
+
+rng_botwoon_set_first:
+{
+    LDX #$0000
+    LDA !ram_botwoon_rng : AND !BOTWOON_RNG_FIRST_MASK
+  .first_loop
+    CMP.l rng_botwoon_first_table,X : BEQ .end_first_loop
+    INX #2 : CPX #$001E : BNE .first_loop
+  .end_first_loop
+    TXA : LSR : STA !ram_cm_botwoon_first_rng
+    LDA !ROOM_ID : CMP.w #ROOM_BotwoonRoom : BNE .done
+    JML init_botwoon_rng
+  .done
+    RTL
+}
+
+rng_botwoon_first_bottom:
+    %cm_toggle_bit_inverted("First LB Bottom", !ram_botwoon_rng, #$0010, rng_botwoon_set_first)
+
+rng_botwoon_first_top:
+    %cm_toggle_bit_inverted("First LT Top", !ram_botwoon_rng, #$0020, rng_botwoon_set_first)
+
+rng_botwoon_first_right:
+    %cm_toggle_bit_inverted("First LR Right", !ram_botwoon_rng, #$0040, rng_botwoon_set_first)
+
+rng_botwoon_first_left:
+    %cm_toggle_bit_inverted("First LL Left", !ram_botwoon_rng, #$0080, rng_botwoon_set_first)
 
 rng_botwoon_hidden:
     dw !ACTION_CHOICE
@@ -3829,7 +3875,7 @@ rng_botwoon_hidden:
     STA !ram_botwoon_rng
     LDA !ram_cm_botwoon_hidden_rng : BEQ .checkRoom
     ; possible values are $01, $09, $11
-    DEC : ASL #3 : INC : XBA : LSR
+    DEC : ASL #3 : INC : XBA
     ORA !ram_botwoon_rng : STA !ram_botwoon_rng
   .checkRoom
     LDA !ROOM_ID : CMP.w #ROOM_BotwoonRoom : BNE .done
@@ -3853,7 +3899,7 @@ rng_botwoon_second:
     STA !ram_botwoon_rng
     LDA !ram_cm_botwoon_second_rng : BEQ .checkRoom
     ; possible values are $01, $09, $11, $19
-    DEC : ASL #3 : INC : XBA : ASL
+    DEC : ASL #3 : INC : XBA : ASL #2
     ORA !ram_botwoon_rng : STA !ram_botwoon_rng
   .checkRoom
     LDA !ROOM_ID : CMP.w #ROOM_BotwoonRoom : BNE .done

--- a/src/menu.asm
+++ b/src/menu.asm
@@ -1646,6 +1646,16 @@ draw_ram_watch:
     LDX #$05D2 ; position for left hex
     LDA !ram_watch_left : CLC : ADC !ram_watch_left_index : STA !DP_Address
     LDA !ram_watch_bank : STA !DP_Address+2
+    CMP #$007E : BEQ .check_left_dp
+    BIT #$0040 : BNE .get_left_value
+  .check_left_dp
+    LDA !DP_Address : CMP.w #!DP_REGISTER_BACKUP_SIZE : BCS .get_left_value
+
+    ; User wants to view a DP register that we backed up
+    CLC : ADC #!DP_REGISTER_BACKUP_START : STA !DP_Address
+    LDA #$007E : STA !DP_Address+2
+
+  .get_left_value
     LDA [!DP_Address] : STA !DP_DrawValue
 
     ; check if 8-bit mode
@@ -1674,6 +1684,17 @@ draw_ram_watch:
 
     LDX #$05E8 ; position for right hex
     LDA !ram_watch_right : CLC : ADC !ram_watch_right_index : STA !DP_Address
+    LDA !ram_watch_bank : STA !DP_Address+2
+    CMP #$007E : BEQ .check_right_dp
+    BIT #$0040 : BNE .get_right_value
+  .check_right_dp
+    LDA !DP_Address : CMP.w #!DP_REGISTER_BACKUP_SIZE : BCS .get_right_value
+
+    ; User wants to view a DP register that we backed up
+    CLC : ADC #!DP_REGISTER_BACKUP_START : STA !DP_Address
+    LDA #$007E : STA !DP_Address+2
+
+  .get_right_value
     LDA [!DP_Address] : STA !DP_DrawValue
 
     ; check if 8-bit mode

--- a/src/misc.asm
+++ b/src/misc.asm
@@ -488,20 +488,11 @@ handle_gold_block_pointer:
 
 
 org $949422
-    JMP hook_horizontal_extension_reaction
+    ; Replace AND #$00FF with NOP since it is not needed,
+    ; but we still want to burn a little CPU for parity with vanilla
+    NOP : BRA $05
 hook_gold_block:
     dw #handle_gold_block_pointer
-
-
-%startfree(94)
-
-hook_horizontal_extension_reaction:
-{
-    AND #$00FF
-    JMP $942A
-}
-
-%endfree(94)
 
 
 org $869D59

--- a/src/misc.asm
+++ b/src/misc.asm
@@ -94,9 +94,18 @@ org $90E874
 else
 org $90E877
 endif
+    LDA !sram_fast_teleport : BNE .fast
+    JSR $8000
+    STZ !ELEVATOR_STATUS
+    LDA !SAMUS_Y : STA !SAMUS_PREVIOUS_Y
+    JSL $92ED24
+    BCC $18
+    BRA .end
+  .fast
     LDA !MUSIC_TRACK
     JSL $808FC1 ; queue room music track
-    BRA $18
+  .end
+%warnpc($90E898, $90E895)
 
 
 ; $82:8BB3 22 69 91 A0 JSL $A09169[$A0:9169]  ; Handles Samus getting hurt?

--- a/src/ramwatchmenu.asm
+++ b/src/ramwatchmenu.asm
@@ -666,6 +666,14 @@ ramwatch_execute_left:
   .routine
     LDA !ram_watch_left : CLC : ADC !ram_watch_left_index : STA $C1
     LDA !ram_watch_bank : STA $C3
+    CMP #$007E : BEQ .checkDP
+    BIT #$0040 : BNE .applyWriteMode
+  .checkDP
+    LDA $C1 : CMP.w #!DP_REGISTER_BACKUP_SIZE : BCS .applyWriteMode
+    ; User wants to set a DP register that we backed up
+    CLC : ADC #!DP_REGISTER_BACKUP_START : STA $C1
+    LDA #$007E : STA $C3
+  .applyWriteMode
     LDA !ram_watch_write_mode : BEQ .setValue
     %a8()
   .setValue
@@ -678,18 +686,20 @@ ramwatch_execute_right:
   .routine
     LDA !ram_watch_right : CLC : ADC !ram_watch_right_index : STA $C1
     LDA !ram_watch_bank : STA $C3
+    CMP #$007E : BEQ .checkDP
+    BIT #$0040 : BNE .applyWriteMode
+  .checkDP
+    LDA $C1 : CMP.w #!DP_REGISTER_BACKUP_SIZE : BCS .applyWriteMode
+    ; User wants to set a DP register that we backed up
+    CLC : ADC #!DP_REGISTER_BACKUP_START : STA $C1
+    LDA #$007E : STA $C3
+  .applyWriteMode
     LDA !ram_watch_write_mode : BEQ .setValue
     %a8()
   .setValue
     LDA !ram_watch_edit_right : STA [$C1]
     %a16()
-    BRA action_HUD_ramwatch
-
-ramwatch_lock_left:
-    %cm_toggle("Lock Left Value", !ram_watch_edit_lock_left, #$01, #action_HUD_ramwatch)
-
-ramwatch_lock_right:
-    %cm_toggle("Lock Right Value", !ram_watch_edit_lock_right, #$01, #action_HUD_ramwatch)
+    ; Fallthrough
 
 action_HUD_ramwatch:
 {
@@ -705,6 +715,12 @@ action_HUD_ramwatch:
     %sfxconfirm()
     JML init_print_segment_timer
 }
+
+ramwatch_lock_left:
+    %cm_toggle("Lock Left Value", !ram_watch_edit_lock_left, #$01, #action_HUD_ramwatch)
+
+ramwatch_lock_right:
+    %cm_toggle("Lock Right Value", !ram_watch_edit_lock_right, #$01, #action_HUD_ramwatch)
 
 ramwatch_display:
     dw !ACTION_RAM_WATCH ; menu action index

--- a/src/ramwatchmenu.asm
+++ b/src/ramwatchmenu.asm
@@ -602,14 +602,16 @@ ramwatch_common_addr1:
     %cm_jsl("Address 1 (Left)", .routine, #$0000)
   .routine
     LDA !ram_cm_watch_common_address : STA !ram_watch_left
-    TDC : STA !ram_watch_left_index : STA !ram_watch_bank
+    TDC : STA !ram_watch_left_index
+    LDA #$007E : STA !ram_watch_bank
     BRA ramwatch_common_addr_done
 
 ramwatch_common_addr2:
     %cm_jsl("Address 2 (Right)", .routine, #$0000)
   .routine
     LDA !ram_cm_watch_common_address : STA !ram_watch_right
-    TDC : STA !ram_watch_right_index : STA !ram_watch_bank
+    TDC : STA !ram_watch_right_index
+    LDA #$007E : STA !ram_watch_bank
 
 ramwatch_common_addr_done:
     LDY #RAMWatchMenu

--- a/src/spritefeat.asm
+++ b/src/spritefeat.asm
@@ -101,18 +101,18 @@ draw_sprite_oob:
 {
     !oob_width = $000D
     !oob_height = $0009
-    LDA !OAM_STACK_POINTER : STA $C8
+    LDA !OAM_STACK_POINTER : STA $C9
 
     ; Samus X - (oob_width*8)
     LDA !SAMUS_X : SEC : SBC #(!oob_width*8) : STA $12
-    AND #$000F : STA $C4
+    AND #$000F : STA $C5
 
     ; [Samus X - (oob_width*8)] / 16
     LDA $12 : LSR #4 : STA $22
 
     ; Samus Y - (oob_height*8)
     LDA !SAMUS_Y : SEC : SBC #((!oob_height-2)*8) : STA $14
-    AND #$000F : STA $C6
+    AND #$000F : STA $C7
 
     ; [Samus Y - (oob_height*8)] / 16
     LDA $14 : LSR #4 : STA $24
@@ -133,7 +133,7 @@ draw_sprite_oob:
   .loop_x
     PHY : PHX
     %a16()
-    STX $C0 : STY $C2
+    STX $C1 : STY $C3
 
     ; X + [Samus X - (oob_width*8)] / 16
     TXA : CLC : ADC $22 : AND #$0FFF
@@ -143,20 +143,52 @@ draw_sprite_oob:
     ; a = a * 2
     ASL : TAX
     ; Load clipdata of block
-    LDA !LEVEL_DATA+1,X : AND #$00FF : LSR #4 : TAX
-    ; Get sprite ID for this BTS
-    LDA.l block_gfx,X : AND #$00FF : CMP #$00D0 : BEQ .next
+    LDA !LEVEL_DATA+1,X : AND #$00F0
+    CMP #$00D0 : BEQ .vertical : CMP #$0050 : BNE .get_sprite_id
+
+  .horizontal
+    ; Horizontal extension, try once to resolve it
+    TXA : LSR : TAX
+    LDA !LEVEL_BTS,X : AND #$00FF : BEQ .next
+    BIT #$0080 : BEQ .horizontal_addition
+    ORA #$FF00
+  .horizontal_addition
+    PHX : CLC : ADC 1,S : PLX
+    BRA .extension_block
+
+  .vertical
+    ; Vertical extension, try once to resolve it
+    TXA : LSR : TAX
+    LDA !LEVEL_BTS,X : AND #$00FF : BEQ .next
+    PHX
+    BIT #$0080 : BNE .negative_vertical
+    TAX
+    PLA
+  .loop_positive_vertical
+    CLC : ADC !ROOM_WIDTH_BLOCKS
+    DEX : BNE .loop_positive_vertical
+
+  .extension_block
+    ASL : TAX
+    LDA !LEVEL_DATA+1,X : AND #$00F0
+
+  .get_sprite_id
+    ; Get sprite ID for this block type
+    CMP #$0030 : BEQ .check_scroll
+    LSR #3 : TAX
+  .get_block_gfx
+    LDA.l block_gfx,X : BEQ .next
 
     ; Set sprite ID
     %a8()
     LDY !OAM_STACK_POINTER : STA $0372,Y
 
     ; Get X coord
-    LDA $C0 : INC #2 : ASL #4 : SEC : SBC $C4
+    LDA $C1 : INC #2 : ASL #4 : SEC : SBC $C5
     STA $0370,Y
 
     ; Get Y coord
-    LDA $C2 : CLC : ADC #$04 : ASL #4 : SEC : SBC $C6
+    LDA $C3 : CLC : ADC #$04 : ASL #4 : SEC : SBC $C7
     STA $0371,Y
 
     ; Sprite Attributes - xxxxxxxx yyyyyyyy YXPPpppt tttttttt
@@ -176,17 +208,38 @@ draw_sprite_oob:
     INX : CPX #!oob_width : BEQ .end_x
     JMP .loop_x
 
+  .negative_vertical
+    ORA #$FF00 : TAX
+    PLA
+  .loop_negative_vertical
+    SEC : SBC !ROOM_WIDTH_BLOCKS
+    INX : BNE .loop_negative_vertical
+
+    ; For negative vertical extension into horizontal extension,
+    ; allow one more attempt (handles 2x2 blocks)
+    ASL : TAX
+    LDA !LEVEL_DATA+1,X : AND #$00F0
+    CMP #$0050 : BNE .get_sprite_id
+    JMP .horizontal
+
+  .check_scroll
+    TXA : LSR : TAX
+    LDA !LEVEL_BTS,X : AND #$00FF
+    CMP #$0046 : BEQ .next
+    LDX #$0006
+    BRA .get_block_gfx
+
   .end_x
     INY : CPY #!oob_height : BEQ .end_y
     JMP .loop_y
 
   .end_y
     LDA !OAM_STACK_POINTER : BEQ .end
-    LSR #4 : INC : STA $CA
-    LDA $C8 : LSR #4 : STA $C8
+    LSR #4 : INC : STA $CB
+    LDA $C9 : LSR #4 : STA $C9
 
     %a8()
-    LDX $C8
+    LDX $C9
 
   .copy_loop
     ; $0570..8F: High OAM. 2 bit entries
@@ -197,7 +250,7 @@ draw_sprite_oob:
     ; c: sx for sprite 4n+2
     ; d: sx for sprite 4n+3
     LDA #%10101010 : STA $0570,X
-    INX : CPX $CA : BNE .copy_loop
+    INX : CPX $CB : BNE .copy_loop
     %ai16()
 
   .end
@@ -205,7 +258,7 @@ draw_sprite_oob:
     RTS
 
 block_gfx:
-    ; D0 = transparent
+    ; 00 = transparent
     ; D2 = white
     ; D4 = yellow
     ; D6 = brown
@@ -214,8 +267,8 @@ block_gfx:
     ; DC = blue
     ; DE = mint
 
-    ;  air, slope, air (trick xray), treadmill, ??,       h-extend,  ??,  ??,  solid, door, spike, crumble, shot, v-xtend, grapple, bomb
-    db $D0, $DE,   $D0,              $DC,       $D0,      $D0,       $D0, $D0, $D6,   $D4,  $DC,   $DC,     $D2,  $D0,     $DA,     $DC
+    ;  air,   slope, air (trick xray), treadmill, ??,    h-extend, ??,    ??,    solid, door,  spike, crumble, shot,  v-xtend, grapple, bomb
+    dw $0000, $00DE, $0000,            $00D8,     $0000, $0000,    $0000, $0000, $00D6, $00D4, $00DC, $00DC,   $00D2, $0000,   $00DA,   $00DC
 
 ; draw hitbox around samus for the oob viewer (static position on the screen)
 draw_oob_samus_hitbox:

--- a/src/symbols.asm
+++ b/src/symbols.asm
@@ -526,6 +526,7 @@ sram_zebes_timer = !sram_zebes_timer ; !SRAM_START+$A2
 sram_fast_pause = !sram_fast_pause ; !SRAM_START+$A4
 sram_bonk_indicators = !sram_bonk_indicators ; !SRAM_START+$A6
 sram_speed_booster_physics = !sram_speed_booster_physics ; !SRAM_START+$A8
+sram_fast_teleport = !sram_fast_teleport ; !SRAM_START+$AA
 
 ; ^ FREE SPACE ^ up to +$EC
 

--- a/web/data/changelog.mdx
+++ b/web/data/changelog.mdx
@@ -39,6 +39,7 @@
 - Add any% glitched RAM addresses (2.7.4.5)
 - Cross-referenced any% glitched RAM addresses with the disassembly (2.7.4.6)
 - Improved fix for preserving DP registers when opening/closing the menu (2.7.4.7)
+- Fix RAM watch bank snapping to 00 and improve OOB tile viewer (2.7.4.8)
 
 # Version 2.6.x
 - Optimize kraid rock projectiles to reduce lag when Kraid rises (2.6.0)

--- a/web/data/changelog.mdx
+++ b/web/data/changelog.mdx
@@ -39,7 +39,9 @@
 - Add any% glitched RAM addresses (2.7.4.5)
 - Cross-referenced any% glitched RAM addresses with the disassembly (2.7.4.6)
 - Improved fix for preserving DP registers when opening/closing the menu (2.7.4.7)
-- Fix RAM watch bank snapping to 00 and improve OOB tile viewer (2.7.4.8)
+- Fix RAM watch bank snapping to 00 and improve OOB tile viewer (2.7.5)
+- Allow DP registers in 00-2F range to be read and written to in RAM watch menu (2.7.5)
+- Add more Botwoon first pattern RNG options and option to disable fast teleport (2.7.5)
 
 # Version 2.6.x
 - Optimize kraid rock projectiles to reduce lag when Kraid rises (2.6.0)

--- a/web/data/config.json
+++ b/web/data/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Super Metroid Practice Hack",
-    "version": "2.7.4.8",
+    "version": "2.7.5",
     "variants": ["NTSC", "PAL"],
     "base": {
         "NTSC": {

--- a/web/data/config.json
+++ b/web/data/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Super Metroid Practice Hack",
-    "version": "2.7.4.7",
+    "version": "2.7.4.8",
     "variants": ["NTSC", "PAL"],
     "base": {
         "NTSC": {


### PR DESCRIPTION
I'll try attaching an image of how a section of parlor used to look.  The 1x2 and 2x2 bomb blocks do not all show up.  Additionally scroll blocks (which are air) appear as blue blocks.  While I understand why these special air blocks were being drawn (they're sometimes relevant, although I'm going to draw them as pink instead of blue), I don't want to see scroll blocks, so I'm excluding those.  These changes also fix door caps (all shot blocks appear instead of just the primary shot block), and they also help with the any% glitched route.  There's a bomb block (via vertical extension) that we jump on that previously didn't appear on the OOB tile viewer but now it does.  Also fixed a glitch with the RAM watch menu (we should default to bank 7E not 00).

<img width="691" height="575" alt="image" src="https://github.com/user-attachments/assets/3ed619f4-e902-447e-9fa3-7bdcfcd5474b" />
