### PR TITLE
Prevent OOB Tile Viewer cleanup from disrupting the carry flag

### DIFF
--- a/src/main.asm
+++ b/src/main.asm
@@ -17,7 +17,7 @@ lorom
 !VERSION_MAJOR = 2
 !VERSION_MINOR = 7
 !VERSION_BUILD = 5
-!VERSION_REV   = 1
+!VERSION_REV   = 2
 
 table ../resources/normal.tbl
 print ""

--- a/src/misc.asm
+++ b/src/misc.asm
@@ -469,7 +469,7 @@ hide_sprite_features:
 
 handle_gold_block:
 {
-    PHA
+    PHA : PHP
     LDA !ram_sprite_feature_flags : BEQ .continue
 
     ; Remove up to either stack pointer or #$0384
@@ -486,7 +486,7 @@ handle_gold_block:
     ; Fix up the PLM
     LDA #$0380 : TAX : STA !PLM_ID,Y
     LDA $0382 : STA !PLM_INSTRUCTION_POINTER,Y
-    PLA
+    PLP : PLA
     JMP ($0380)
 }
 

--- a/src/ramwatchmenu.asm
+++ b/src/ramwatchmenu.asm
@@ -563,7 +563,7 @@ ramwatch_common_anyglitched_090F:
     %cm_jsl("090F Layer 1 SubX     --F-", action_select_common_address, #!LAYER1_SUB_X)
 
 ramwatch_common_anyglitched_0913:
-    %cm_jsl("0913 Layer 1 SubY     --0-", action_select_common_address, #!LAYER1_SUB_Y)
+    %cm_jsl("0913 Layer 1 SubY     --F-", action_select_common_address, #!LAYER1_SUB_Y)
 
 ramwatch_common_anyglitched_0C5E:
     %cm_jsl("0C5E Bomb One Geemer  F---", action_select_common_address, #!SAMUS_BOMB_INSTRUCTION_TIMER)
@@ -572,10 +572,10 @@ ramwatch_common_anyglitched_0E20:
     %cm_jsl("0E20 5olD Geemer Side F---", action_select_common_address, #$0E20)
 
 ramwatch_common_anyglitched_11FC:
-    %cm_jsl("11FC 5olD Geemer SubX -F--", action_select_common_address, #(!ENEMY_X_SUBPX+$280))
+    %cm_jsl("11FC 5olD Geemer SubX --F-", action_select_common_address, #(!ENEMY_X_SUBPX+$280))
 
 ramwatch_common_anyglitched_1200:
-    %cm_jsl("1200 5olD Geemer SubY -F--", action_select_common_address, #(!ENEMY_Y_SUBPX+$280))
+    %cm_jsl("1200 5olD Geemer SubY --F-", action_select_common_address, #(!ENEMY_Y_SUBPX+$280))
 
 ramwatch_common_anyglitched_1842:
     %cm_jsl("1842 Time Since Reset 1---", action_select_common_address, #!EARTHQUAKE_EXECUTION_COUNT)

--- a/web/data/changelog.mdx
+++ b/web/data/changelog.mdx
@@ -43,6 +43,7 @@
 - Allow DP registers in 00-2F range to be read and written to in RAM watch menu (2.7.5)
 - Add more Botwoon first pattern RNG options and option to disable fast teleport (2.7.5)
 - Added 03D6 address to any% glitched RAM watch common addresses (2.7.5.1)
+- Small RAM watch adjustments and fix temperamental OOB tile viewer X-ray collection (2.7.5.2)
 
 # Version 2.6.x
 - Optimize kraid rock projectiles to reduce lag when Kraid rises (2.6.0)

--- a/web/data/config.json
+++ b/web/data/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Super Metroid Practice Hack",
-    "version": "2.7.5.1",
+    "version": "2.7.5.2",
     "variants": ["NTSC", "PAL"],
     "base": {
         "NTSC": {


### PR DESCRIPTION
Sometimes X-ray collection works with OOB Tile Viewer and sometimes it doesn't.  I believe this is the reason.  It's seems to be working better now.