### PR TITLE
Release 2.7.5.3

### DIFF
--- a/src/infohudmodes.asm
+++ b/src/infohudmodes.asm
@@ -893,14 +893,14 @@ endif
     ; If speed was previously negative, then proceed to draw negative speed
     TAY : LDA !ram_momentum_sum : AND #$8000 : BNE .negativespeed
 
-    LDA !IH_BLANK : STA !HUD_TILEMAP+$88 : STA !HUD_TILEMAP+$90
-    LDA !IH_HYPHEN : STA !HUD_TILEMAP+$8A : STA !HUD_TILEMAP+$8E
-    LDA !IH_DECIMAL : STA !HUD_TILEMAP+$8C
+    LDA !IH_HYPHEN : STA !HUD_TILEMAP+$88
+    STA !HUD_TILEMAP+$8C : STA !HUD_TILEMAP+$8E
+    LDA !IH_DECIMAL : STA !HUD_TILEMAP+$8A
 
     ; Store speed as some negative value that isn't FFxx,
     ; so if it is negative again we'll update it
     LDA #$8000 : STA !ram_momentum_sum
-    BRA .checkfalling
+    BRA .drawblankcheckfalling
 
   .negativespeed
     TYA : STA !ram_momentum_sum
@@ -911,11 +911,14 @@ endif
     CMP !ram_momentum_sum : BEQ .checkfalling : STA !ram_momentum_sum
 
     ; draw whole number in decimal
-    XBA : AND #$00FF : LDX #$0088 : JSR Draw2
-    LDA !IH_DECIMAL : STA !HUD_TILEMAP+$8C
+    TAX : XBA : AND #$00FF
+    ASL : TAY : LDA.w NumberGFXTable,Y : STA !HUD_TILEMAP+$88
+    LDA !IH_DECIMAL : STA !HUD_TILEMAP+$8A
 
     ; draw fraction in hex
-    LDA !ram_momentum_sum : AND #$00F0 : LSR #3 : TAY
+    TXA : AND #$00F0 : LSR #3 : TAY
+    LDA.w HexGFXTable,Y : STA !HUD_TILEMAP+$8C
+    TXA : AND #$000F : ASL : TAY
     LDA.w HexGFXTable,Y : STA !HUD_TILEMAP+$8E
 
   .drawblankcheckfalling

--- a/src/main.asm
+++ b/src/main.asm
@@ -17,7 +17,7 @@ lorom
 !VERSION_MAJOR = 2
 !VERSION_MINOR = 7
 !VERSION_BUILD = 5
-!VERSION_REV   = 2
+!VERSION_REV   = 3
 
 table ../resources/normal.tbl
 print ""

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -2098,6 +2098,7 @@ ihstrat_ceresridley:
     %cm_jsl("Ceres Ridley Hits", #action_select_room_strat, #$0001)
 
 ihstrat_doorskip:
+!IH_STRAT_DOORSKIP_INDEX = #$0002
     %cm_jsl("Parlor/Botwoon Door Skip", #action_select_room_strat, #$0002)
 
 ihstrat_tacotank:
@@ -2444,6 +2445,7 @@ ih_superhud_ceresridley:
     %cm_jsl("Ceres Ridley Hits", #action_select_superhud_bottom, #$001A)
 
 ih_superhud_doorskip:
+!IH_SUPERHUD_DOORSKIP_BOTTOM_INDEX = #$001B
     %cm_jsl("Parlor-Climb Door Skip", #action_select_superhud_bottom, #$001B)
 
 ih_superhud_tacotank:

--- a/src/misc.asm
+++ b/src/misc.asm
@@ -400,6 +400,32 @@ endif
     STA $7F0A9A,X ; !SAMUS_LAVA_DAMAGE_SUITS
     STA $7F0B0E,X ; !DAMAGE_COUNTER
 
+    ; Check if door skip is selected
+    LDA !sram_display_mode : CMP !IH_MODE_ROOMSTRAT_INDEX : BNE .check_sprite_flags
+    LDA !sram_room_strat : BEQ .check_super_hud
+    CMP !IH_STRAT_DOORSKIP_INDEX : BNE .check_sprite_flags
+
+  .draw_earthquake
+    ; Draw value relevant for block shuffler
+    LDA !EARTHQUAKE_EXECUTION_COUNT
+    AND #$F000 : XBA : LSR #3 : TAX
+    LDA.l HexGFXTable,X : STA !HUD_TILEMAP+$88
+    LDA !EARTHQUAKE_EXECUTION_COUNT
+    AND #$0F00 : XBA : ASL : TAX
+    LDA.l HexGFXTable,X : STA !HUD_TILEMAP+$8A
+    LDA !EARTHQUAKE_EXECUTION_COUNT
+    AND #$00F0 : LSR #3 : TAX
+    LDA.l HexGFXTable,X : STA !HUD_TILEMAP+$8C
+    LDA !EARTHQUAKE_EXECUTION_COUNT
+    AND #$000F : ASL : TAX
+    LDA.l HexGFXTable,X : STA !HUD_TILEMAP+$8E
+    BRA .check_sprite_flags
+
+  .check_super_hud
+    LDA !sram_superhud_bottom : CMP !IH_SUPERHUD_DOORSKIP_BOTTOM_INDEX
+    BEQ .draw_earthquake
+
+  .check_sprite_flags
     LDA !ram_sprite_feature_flags : BEQ .end
 
     ; Remove up to !OAM_HIGH

--- a/src/presets/combined_preset_data.asm
+++ b/src/presets/combined_preset_data.asm
@@ -7334,26 +7334,27 @@ preset_rando_four_bosses_xray_climb:
     dw $D8C2, $4D00  ; Doors
     dw #$FFFF
 
-preset_rando_four_bosses_ridley_30_25_5_ammo:
-    dw #preset_rando_red_brinstar_tube_jump_from_left
+preset_rando_four_bosses_ridley_loaded:
+    dw #preset_rando_crocomire_ripper_dboost
     dw $078D, $995A  ; DDB
     dw $079B, $B37A  ; MDB
     dw $07F3, $0018  ; Music Bank
     dw $090F, $A000  ; Screen subpixel X position
     dw $0913, $A400  ; Screen subpixel Y position
-    dw $09A2, $1005  ; Equipped Items
-    dw $09A4, $1005  ; Collected Items
+    dw $0917, $0000  ; Layer 2 X position
+    dw $09A2, $F32F  ; Equipped Items
+    dw $09A4, $F32F  ; Collected Items
+    dw $09A6, $100F  ; Equipped Beams
+    dw $09A8, $100F  ; Collected Beams
     dw $09C2, $0257  ; Health
     dw $09C4, $0257  ; Max health
     dw $09C6, $001E  ; Missiles
     dw $09C8, $001E  ; Max missiles
-    dw $09CA, $0019  ; Supers
-    dw $09CC, $0019  ; Max supers
+    dw $09CA, $001E  ; Supers
+    dw $09CC, $001E  ; Max supers
     dw $09CE, $0005  ; Pbs
-    dw $0A1C, $008A  ; Samus position/state
-    dw $0A1E, $1504  ; More position/state
-    dw $0AF6, $0025  ; Samus X
     dw $0AFA, $009B  ; Samus Y
+    dw $D82A, $0000  ; Bosses
     dw $D8B8, $0E00  ; Doors
     dw $D8BA, $D100  ; Doors
     dw $D8BC, $0001  ; Doors
@@ -7461,18 +7462,6 @@ preset_14speed_wrecked_ship_leaving_gravity:
     dw #preset_14ice_wrecked_ship_leaving_gravity
     dw $09C6, $0002  ; Missiles
     dw $09CE, $0000  ; Pbs
-    dw #$FFFF
-
-preset_rando_four_bosses_ridley_10_20_15_ammo:
-    dw #preset_rando_four_bosses_ridley_30_25_5_ammo
-    dw $09A2, $1025  ; Equipped Items
-    dw $09A4, $1025  ; Collected Items
-    dw $09C6, $000A  ; Missiles
-    dw $09C8, $000A  ; Max missiles
-    dw $09CA, $0014  ; Supers
-    dw $09CC, $0014  ; Max supers
-    dw $09CE, $000F  ; Pbs
-    dw $09D0, $000F  ; Max pbs
     dw #$FFFF
 
 preset_gtmax_brinstar_breaking_the_tube:
@@ -7742,14 +7731,14 @@ preset_nodropskpdr_speed_wave_power_bombs_double_chamber_revisit:
     dw $D8BA, $00B1  ; Doors
     dw #$FFFF
 
-preset_rando_four_bosses_ridley_low_hp:
-    dw #preset_rando_four_bosses_ridley_30_25_5_ammo
-    dw $09A2, $1025  ; Equipped Items
-    dw $09A4, $1025  ; Collected Items
-    dw $09C2, $00C7  ; Health
-    dw $09C4, $00C7  ; Max health
-    dw $09CA, $001E  ; Supers
-    dw $09CC, $001E  ; Max supers
+preset_rando_four_bosses_ridley_30_25_5_ammo:
+    dw #preset_rando_four_bosses_ridley_loaded
+    dw $09A2, $1005  ; Equipped Items
+    dw $09A4, $1005  ; Collected Items
+    dw $09A6, $0000  ; Equipped Beams
+    dw $09A8, $0000  ; Collected Beams
+    dw $09CA, $0019  ; Supers
+    dw $09CC, $0019  ; Max supers
     dw #$FFFF
 
 preset_allbossprkd_upper_norfair_ice_beam_hallway:
@@ -7923,16 +7912,16 @@ preset_14speed_brinstar_revisit_entering_kraids_lair:
     dw $D820, $0801  ; Events
     dw #$FFFF
 
-preset_rando_four_bosses_ridley_low_ice:
-    dw #preset_rando_four_bosses_ridley_low_hp
-    dw $09A6, $1002  ; Equipped Beams
-    dw $09A8, $1002  ; Collected Beams
-    dw $09C2, $018F  ; Health
-    dw $09C4, $018F  ; Max health
+preset_rando_four_bosses_ridley_10_20_15_ammo:
+    dw #preset_rando_four_bosses_ridley_30_25_5_ammo
+    dw $09A2, $1025  ; Equipped Items
+    dw $09A4, $1025  ; Collected Items
     dw $09C6, $000A  ; Missiles
     dw $09C8, $000A  ; Max missiles
-    dw $09CA, $000A  ; Supers
-    dw $09CC, $000A  ; Max supers
+    dw $09CA, $0014  ; Supers
+    dw $09CC, $0014  ; Max supers
+    dw $09CE, $000F  ; Pbs
+    dw $09D0, $000F  ; Max pbs
     dw #$FFFF
 
 preset_rbo_shopping_single_maridia_first_hell_run:
@@ -7947,8 +7936,152 @@ preset_rbo_shopping_single_maridia_first_hell_run:
     dw $D8B6, $B00C  ; Doors
     dw #$FFFF
 
+preset_rando_four_bosses_ridley_low_hp:
+    dw #preset_rando_four_bosses_ridley_loaded
+    dw $09A2, $1025  ; Equipped Items
+    dw $09A4, $1025  ; Collected Items
+    dw $09A6, $0000  ; Equipped Beams
+    dw $09A8, $0000  ; Collected Beams
+    dw $09C2, $00C7  ; Health
+    dw $09C4, $00C7  ; Max health
+    dw #$FFFF
+
+preset_hundo_kraid_leaving_kraid_etank:
+    dw #preset_100early_brinstar_leaving_kraid_etank
+    dw $09C6, $000F  ; Missiles
+    dw #$FFFF
+
+preset_100early_speed_booster_business_center:
+    dw #preset_100early_brinstar_leaving_kraid_etank
+    dw $078D, $9246  ; DDB
+    dw $079B, $A7DE  ; MDB
+    dw $07F3, $0015  ; Music Bank
+    dw $090F, $A000  ; Screen subpixel X position
+    dw $0913, $0000  ; Screen subpixel Y position
+    dw $0915, $0238  ; Screen Y position in pixels
+    dw $0919, $01AA  ; Layer 2 Y position
+    dw $09C6, $0012  ; Missiles
+    dw $09CA, $0004  ; Supers
+    dw $0A1C, $0000  ; Samus position/state
+    dw $0A1E, $0000  ; More position/state
+    dw $0AF6, $0080  ; Samus X
+    dw $0AFA, $02A8  ; Samus Y
+    dw #$FFFF
+
+preset_gtmax_kraids_lair_entering_kraids_lair:
+    dw #preset_gtclassic_kraids_lair_entering_kraids_lair
+    dw $090F, $0000  ; Screen subpixel X position
+    dw $0913, $4C01  ; Screen subpixel Y position
+    dw $09C2, $004B  ; Health
+    dw $09C4, $0063  ; Max health
+    dw $09C6, $0002  ; Missiles
+    dw $09CA, $0005  ; Supers
+    dw $D870, $0080  ; Items
+    dw #$FFFF
+
+preset_kpdr20_upper_norfair_speed_hallway:
+preset_kpdr21_upper_norfair_speed_hallway:
+    dw #preset_nodropskpdr_speed_wave_power_bombs_speed_hallway
+    dw $09C2, $0110  ; Health
+    dw $09C6, $0008  ; Missiles
+    dw $09C8, $000F  ; Max missiles
+    dw $09CC, $0005  ; Max supers
+    dw $D870, $0180  ; Items
+    dw $D872, $04C1  ; Items
+    dw $D8B4, $0206  ; Doors
+    dw #$FFFF
+
+preset_rando_four_bosses_ridley_low_ice:
+    dw #preset_rando_four_bosses_ridley_low_hp
+    dw $09A6, $1002  ; Equipped Beams
+    dw $09A8, $1002  ; Collected Beams
+    dw $09C2, $018F  ; Health
+    dw $09C4, $018F  ; Max health
+    dw $09C6, $000A  ; Missiles
+    dw $09C8, $000A  ; Max missiles
+    dw $09CA, $000A  ; Supers
+    dw $09CC, $000A  ; Max supers
+    dw #$FFFF
+
+preset_gtclassic_kraids_lair_kraid_kihunters:
+    dw #preset_gtclassic_kraids_lair_entering_kraids_lair
+    dw $078D, $923A  ; DDB
+    dw $079B, $A471  ; MDB
+    dw $090F, $8000  ; Screen subpixel X position
+    dw $0911, $0100  ; Screen X position in pixels
+    dw $0913, $83FF  ; Screen subpixel Y position
+    dw $0917, $00C0  ; Layer 2 X position
+    dw $09CA, $0003  ; Supers
+    dw $0AF6, $0167  ; Samus X
+    dw #$FFFF
+
+preset_kpdr20_upper_norfair_bat_cave_revisit:
+preset_kpdr21_upper_norfair_bat_cave_revisit:
+    dw #preset_nodropskpdr_speed_wave_power_bombs_bat_cave_revisit
+    dw $09C2, $0110  ; Health
+    dw $09C6, $0008  ; Missiles
+    dw $09C8, $000F  ; Max missiles
+    dw $09CC, $0005  ; Max supers
+    dw $D870, $0180  ; Items
+    dw $D872, $04C1  ; Items
+    dw $D878, $0004  ; Items
+    dw $D8B4, $0206  ; Doors
+    dw #$FFFF
+
+preset_kpdr20_upper_norfair_single_chamber:
+preset_kpdr21_upper_norfair_single_chamber:
+    dw #preset_allbosskpdr_upper_norfair_single_chamber
+    dw $090F, $BFFF  ; Screen subpixel X position
+    dw $0915, $0104  ; Screen Y position in pixels
+    dw $0917, $00C0  ; Layer 2 X position
+    dw $0919, $00C3  ; Layer 2 Y position
+    dw $0AF6, $01AD  ; Samus X
+    dw $0AF8, $FFFF  ; Samus subpixel X
+    dw $D8B8, $26ED  ; Doors
+    dw #$FFFF
+
+preset_kpdr23_kraid_leaving_kraid_etank:
+    dw #preset_100early_brinstar_leaving_kraid_etank
+    dw $09C0, $0000  ; Manual/Auto reserve tank
+    dw $09C6, $0009  ; Missiles
+    dw $09C8, $000A  ; Max missiles
+    dw $09D4, $0000  ; Max reserves
+    dw $09D6, $0000  ; Reserves
+    dw $0AF6, $008E  ; Samus X
+    dw $0AF8, $3000  ; Samus subpixel X
+    dw $D870, $0180  ; Items
+    dw $D872, $04C1  ; Items
+    dw $D8B4, $0206  ; Doors
+    dw #$FFFF
+
+preset_kpdr23_kraid_business_center_preelev:
+    dw #preset_kpdr20_kraid_business_center_preelev
+    dw $09A6, $1004  ; Equipped Beams
+    dw $09A8, $1004  ; Collected Beams
+    dw $09C2, $012B  ; Health
+    dw $09C4, $012B  ; Max health
+    dw $09C6, $000A  ; Missiles
+    dw $0AF8, $3000  ; Samus subpixel X
+    dw $D874, $0C04  ; Items
+    dw $D8B6, $8008  ; Doors
+    dw $D8B8, $00EF  ; Doors
+    dw #$FFFF
+
+preset_kpdr23_upper_norfair_business_center_postelev:
+    dw #preset_kpdr20_upper_norfair_business_center_postelev
+    dw $09A6, $1004  ; Equipped Beams
+    dw $09A8, $1004  ; Collected Beams
+    dw $09C2, $012B  ; Health
+    dw $09C4, $012B  ; Max health
+    dw $09C6, $000A  ; Missiles
+    dw $0AF8, $3000  ; Samus subpixel X
+    dw $D874, $0C04  ; Items
+    dw $D8B6, $8008  ; Doors
+    dw $D8B8, $00EF  ; Doors
+    dw #$FFFF
+
 preset_rando_four_bosses_ridley_suitless:
-    dw #preset_rando_four_bosses_ridley_30_25_5_ammo
+    dw #preset_rando_four_bosses_ridley_low_hp
     dw $09A2, $1004  ; Equipped Items
     dw $09A4, $1004  ; Collected Items
     dw $09C0, $0001  ; Manual/Auto reserve tank
@@ -7998,155 +8131,6 @@ preset_rando_upper_norfair_ice_return:
     dw $D82A, $0000  ; Bosses
     dw $D876, $0004  ; Items
     dw $D8B8, $0800  ; Doors
-    dw #$FFFF
-
-preset_hundo_kraid_leaving_kraid_etank:
-    dw #preset_100early_brinstar_leaving_kraid_etank
-    dw $09C6, $000F  ; Missiles
-    dw #$FFFF
-
-preset_100early_speed_booster_business_center:
-    dw #preset_100early_brinstar_leaving_kraid_etank
-    dw $078D, $9246  ; DDB
-    dw $079B, $A7DE  ; MDB
-    dw $07F3, $0015  ; Music Bank
-    dw $090F, $A000  ; Screen subpixel X position
-    dw $0913, $0000  ; Screen subpixel Y position
-    dw $0915, $0238  ; Screen Y position in pixels
-    dw $0919, $01AA  ; Layer 2 Y position
-    dw $09C6, $0012  ; Missiles
-    dw $09CA, $0004  ; Supers
-    dw $0A1C, $0000  ; Samus position/state
-    dw $0A1E, $0000  ; More position/state
-    dw $0AF6, $0080  ; Samus X
-    dw $0AFA, $02A8  ; Samus Y
-    dw #$FFFF
-
-preset_gtmax_kraids_lair_entering_kraids_lair:
-    dw #preset_gtclassic_kraids_lair_entering_kraids_lair
-    dw $090F, $0000  ; Screen subpixel X position
-    dw $0913, $4C01  ; Screen subpixel Y position
-    dw $09C2, $004B  ; Health
-    dw $09C4, $0063  ; Max health
-    dw $09C6, $0002  ; Missiles
-    dw $09CA, $0005  ; Supers
-    dw $D870, $0080  ; Items
-    dw #$FFFF
-
-preset_kpdr20_upper_norfair_speed_hallway:
-preset_kpdr21_upper_norfair_speed_hallway:
-    dw #preset_nodropskpdr_speed_wave_power_bombs_speed_hallway
-    dw $09C2, $0110  ; Health
-    dw $09C6, $0008  ; Missiles
-    dw $09C8, $000F  ; Max missiles
-    dw $09CC, $0005  ; Max supers
-    dw $D870, $0180  ; Items
-    dw $D872, $04C1  ; Items
-    dw $D8B4, $0206  ; Doors
-    dw #$FFFF
-
-preset_gtclassic_kraids_lair_kraid_kihunters:
-    dw #preset_gtclassic_kraids_lair_entering_kraids_lair
-    dw $078D, $923A  ; DDB
-    dw $079B, $A471  ; MDB
-    dw $090F, $8000  ; Screen subpixel X position
-    dw $0911, $0100  ; Screen X position in pixels
-    dw $0913, $83FF  ; Screen subpixel Y position
-    dw $0917, $00C0  ; Layer 2 X position
-    dw $09CA, $0003  ; Supers
-    dw $0AF6, $0167  ; Samus X
-    dw #$FFFF
-
-preset_kpdr20_upper_norfair_bat_cave_revisit:
-preset_kpdr21_upper_norfair_bat_cave_revisit:
-    dw #preset_nodropskpdr_speed_wave_power_bombs_bat_cave_revisit
-    dw $09C2, $0110  ; Health
-    dw $09C6, $0008  ; Missiles
-    dw $09C8, $000F  ; Max missiles
-    dw $09CC, $0005  ; Max supers
-    dw $D870, $0180  ; Items
-    dw $D872, $04C1  ; Items
-    dw $D878, $0004  ; Items
-    dw $D8B4, $0206  ; Doors
-    dw #$FFFF
-
-preset_kpdr20_upper_norfair_single_chamber:
-preset_kpdr21_upper_norfair_single_chamber:
-    dw #preset_allbosskpdr_upper_norfair_single_chamber
-    dw $090F, $BFFF  ; Screen subpixel X position
-    dw $0915, $0104  ; Screen Y position in pixels
-    dw $0917, $00C0  ; Layer 2 X position
-    dw $0919, $00C3  ; Layer 2 Y position
-    dw $0AF6, $01AD  ; Samus X
-    dw $0AF8, $FFFF  ; Samus subpixel X
-    dw $D8B8, $26ED  ; Doors
-    dw #$FFFF
-
-preset_rando_upper_norfair_crumble_shaft:
-    dw #preset_rando_upper_norfair_ice_hellrun
-    dw $078D, $92BE  ; DDB
-    dw $079B, $A815  ; MDB
-    dw $090F, $E301  ; Screen subpixel X position
-    dw $0913, $1400  ; Screen subpixel Y position
-    dw $0915, $0300  ; Screen Y position in pixels
-    dw $0919, $0240  ; Layer 2 Y position
-    dw $09CE, $0003  ; Pbs
-    dw $0A1C, $008A  ; Samus position/state
-    dw $0A1E, $1504  ; More position/state
-    dw $0AFA, $038B  ; Samus Y
-    dw #$FFFF
-
-preset_kpdr23_kraid_leaving_kraid_etank:
-    dw #preset_100early_brinstar_leaving_kraid_etank
-    dw $09C0, $0000  ; Manual/Auto reserve tank
-    dw $09C6, $0009  ; Missiles
-    dw $09C8, $000A  ; Max missiles
-    dw $09D4, $0000  ; Max reserves
-    dw $09D6, $0000  ; Reserves
-    dw $0AF6, $008E  ; Samus X
-    dw $0AF8, $3000  ; Samus subpixel X
-    dw $D870, $0180  ; Items
-    dw $D872, $04C1  ; Items
-    dw $D8B4, $0206  ; Doors
-    dw #$FFFF
-
-preset_rando_upper_norfair_crumble_shaft_up:
-    dw #preset_rando_upper_norfair_crumble_shaft
-    dw $078D, $9396  ; DDB
-    dw $079B, $A923  ; MDB
-    dw $090F, $2301  ; Screen subpixel X position
-    dw $0913, $9000  ; Screen subpixel Y position
-    dw $0915, $0000  ; Screen Y position in pixels
-    dw $0919, $0000  ; Layer 2 Y position
-    dw $09C2, $012B  ; Health
-    dw $09C4, $012B  ; Max health
-    dw $0AFA, $008B  ; Samus Y
-    dw #$FFFF
-
-preset_kpdr23_kraid_business_center_preelev:
-    dw #preset_kpdr20_kraid_business_center_preelev
-    dw $09A6, $1004  ; Equipped Beams
-    dw $09A8, $1004  ; Collected Beams
-    dw $09C2, $012B  ; Health
-    dw $09C4, $012B  ; Max health
-    dw $09C6, $000A  ; Missiles
-    dw $0AF8, $3000  ; Samus subpixel X
-    dw $D874, $0C04  ; Items
-    dw $D8B6, $8008  ; Doors
-    dw $D8B8, $00EF  ; Doors
-    dw #$FFFF
-
-preset_kpdr23_upper_norfair_business_center_postelev:
-    dw #preset_kpdr20_upper_norfair_business_center_postelev
-    dw $09A6, $1004  ; Equipped Beams
-    dw $09A8, $1004  ; Collected Beams
-    dw $09C2, $012B  ; Health
-    dw $09C4, $012B  ; Max health
-    dw $09C6, $000A  ; Missiles
-    dw $0AF8, $3000  ; Samus subpixel X
-    dw $D874, $0C04  ; Items
-    dw $D8B6, $8008  ; Doors
-    dw $D8B8, $00EF  ; Doors
     dw #$FFFF
 
 preset_prkd19_wrecked_ship_upper_west_ocean:
@@ -8404,25 +8388,6 @@ preset_rbo_shopping_single_maridia_bubble_mountain:
     dw $D8B6, $B00C  ; Doors
     dw #$FFFF
 
-preset_rando_upper_norfair_cathedral_2tank_hijump:
-    dw #preset_rando_upper_norfair_ice_hellrun
-    dw $078D, $932A  ; DDB
-    dw $090F, $8000  ; Screen subpixel X position
-    dw $0913, $DC00  ; Screen subpixel Y position
-    dw $0915, $0317  ; Screen Y position in pixels
-    dw $0919, $0251  ; Layer 2 Y position
-    dw $09A2, $1104  ; Equipped Items
-    dw $09A4, $1104  ; Collected Items
-    dw $09A6, $1001  ; Equipped Beams
-    dw $09A8, $1001  ; Collected Beams
-    dw $09C2, $012B  ; Health
-    dw $09C4, $012B  ; Max health
-    dw $0A1C, $0001  ; Samus position/state
-    dw $0A1E, $0008  ; More position/state
-    dw $0AF6, $00A3  ; Samus X
-    dw $0AFA, $038B  ; Samus Y
-    dw #$FFFF
-
 preset_rbo_shopping_double_maridia_wave_escape:
     dw #preset_rbo_shopping_double_maridia_leaving_speed_farm_2
     dw $078D, $961E  ; DDB
@@ -8455,6 +8420,20 @@ preset_rbo_shopping_single_maridia_bat_cave_farm_1:
     dw $D8BA, $0011  ; Doors
     dw #$FFFF
 
+preset_rando_upper_norfair_crumble_shaft:
+    dw #preset_rando_upper_norfair_ice_hellrun
+    dw $078D, $92BE  ; DDB
+    dw $079B, $A815  ; MDB
+    dw $090F, $E301  ; Screen subpixel X position
+    dw $0913, $1400  ; Screen subpixel Y position
+    dw $0915, $0300  ; Screen Y position in pixels
+    dw $0919, $0240  ; Layer 2 Y position
+    dw $09CE, $0003  ; Pbs
+    dw $0A1C, $008A  ; Samus position/state
+    dw $0A1E, $1504  ; More position/state
+    dw $0AFA, $038B  ; Samus Y
+    dw #$FFFF
+
 preset_ngplasma_norfair_postridley_wasteland_revisit:
     dw #preset_nghyper_norfair_postridley_wasteland_revisit
     dw $090F, $9000  ; Screen subpixel X position
@@ -8481,6 +8460,19 @@ preset_nghyper_norfair_postridley_fireflea_room:
     dw $09CE, $0028  ; Pbs
     dw $0AF6, $00A3  ; Samus X
     dw $0AF8, $3FFF  ; Samus subpixel X
+    dw #$FFFF
+
+preset_rando_upper_norfair_crumble_shaft_up:
+    dw #preset_rando_upper_norfair_crumble_shaft
+    dw $078D, $9396  ; DDB
+    dw $079B, $A923  ; MDB
+    dw $090F, $2301  ; Screen subpixel X position
+    dw $0913, $9000  ; Screen subpixel Y position
+    dw $0915, $0000  ; Screen Y position in pixels
+    dw $0919, $0000  ; Layer 2 Y position
+    dw $09C2, $012B  ; Health
+    dw $09C4, $012B  ; Max health
+    dw $0AFA, $008B  ; Samus Y
     dw #$FFFF
 
 preset_ngplasma_norfair_postridley_kihunter_stairs_up:
@@ -8572,6 +8564,25 @@ preset_hundo_speed_booster_business_center:
     dw $0A1C, $009B  ; Samus position/state
     dw #$FFFF
 
+preset_rando_upper_norfair_cathedral_2tank_hijump:
+    dw #preset_rando_upper_norfair_ice_hellrun
+    dw $078D, $932A  ; DDB
+    dw $090F, $8000  ; Screen subpixel X position
+    dw $0913, $DC00  ; Screen subpixel Y position
+    dw $0915, $0317  ; Screen Y position in pixels
+    dw $0919, $0251  ; Layer 2 Y position
+    dw $09A2, $1104  ; Equipped Items
+    dw $09A4, $1104  ; Collected Items
+    dw $09A6, $1001  ; Equipped Beams
+    dw $09A8, $1001  ; Collected Beams
+    dw $09C2, $012B  ; Health
+    dw $09C4, $012B  ; Max health
+    dw $0A1C, $0001  ; Samus position/state
+    dw $0A1E, $0008  ; More position/state
+    dw $0AF6, $00A3  ; Samus X
+    dw $0AFA, $038B  ; Samus Y
+    dw #$FFFF
+
 preset_allbosspkdr_upper_norfair_bubble_mountain_revisit:
     dw #preset_allbosspkdr_upper_norfair_double_chamber_revisit
     dw $078D, $9606  ; DDB
@@ -8631,40 +8642,6 @@ preset_rando_upper_norfair_mountain_to_kronic:
     dw $D8BA, $0100  ; Doors
     dw #$FFFF
 
-preset_rando_upper_norfair_kronic_to_mountain:
-    dw #preset_rando_upper_norfair_crumble_shaft_up
-    dw $078D, $967E  ; DDB
-    dw $079B, $AF14  ; MDB
-    dw $090F, $DFFF  ; Screen subpixel X position
-    dw $0911, $0300  ; Screen X position in pixels
-    dw $0913, $F800  ; Screen subpixel Y position
-    dw $0917, $0240  ; Layer 2 X position
-    dw $09A2, $5004  ; Equipped Items
-    dw $09A4, $5004  ; Collected Items
-    dw $09CA, $0005  ; Supers
-    dw $09CE, $0005  ; Pbs
-    dw $0A1C, $0089  ; Samus position/state
-    dw $0A1E, $1508  ; More position/state
-    dw $0AF6, $03DB  ; Samus X
-    dw $D8B8, $0E00  ; Doors
-    dw $D8BA, $0100  ; Doors
-    dw #$FFFF
-
-preset_rando_upper_norfair_speedless_speedway:
-    dw #preset_rando_upper_norfair_crumble_shaft_up
-    dw $078D, $97E6  ; DDB
-    dw $079B, $AF72  ; MDB
-    dw $090F, $1000  ; Screen subpixel X position
-    dw $0913, $FC00  ; Screen subpixel Y position
-    dw $09A6, $0007  ; Equipped Beams
-    dw $09A8, $0007  ; Collected Beams
-    dw $09C2, $018F  ; Health
-    dw $09C4, $018F  ; Max health
-    dw $09CA, $0005  ; Supers
-    dw $09CE, $0005  ; Pbs
-    dw $D8B8, $0E00  ; Doors
-    dw #$FFFF
-
 preset_nodropskpdr_speed_wave_power_bombs_frog_speedway:
     dw #preset_nodropskpdr_speed_wave_power_bombs_single_chamber_revisit
     dw $078D, $956A  ; DDB
@@ -8717,6 +8694,25 @@ preset_allbossprkd_upper_norfair_single_chamber:
     dw $D8B4, $2606  ; Doors
     dw $D8B6, $B028  ; Doors
     dw $D8B8, $2E00  ; Doors
+    dw #$FFFF
+
+preset_rando_upper_norfair_kronic_to_mountain:
+    dw #preset_rando_upper_norfair_crumble_shaft_up
+    dw $078D, $967E  ; DDB
+    dw $079B, $AF14  ; MDB
+    dw $090F, $DFFF  ; Screen subpixel X position
+    dw $0911, $0300  ; Screen X position in pixels
+    dw $0913, $F800  ; Screen subpixel Y position
+    dw $0917, $0240  ; Layer 2 X position
+    dw $09A2, $5004  ; Equipped Items
+    dw $09A4, $5004  ; Collected Items
+    dw $09CA, $0005  ; Supers
+    dw $09CE, $0005  ; Pbs
+    dw $0A1C, $0089  ; Samus position/state
+    dw $0A1E, $1508  ; More position/state
+    dw $0AF6, $03DB  ; Samus X
+    dw $D8B8, $0E00  ; Doors
+    dw $D8BA, $0100  ; Doors
     dw #$FFFF
 
 preset_allbossprkd_upper_norfair_double_chamber_revisit:
@@ -8775,6 +8771,21 @@ preset_allbosskpdr_wrecked_ship_entering_wrecked_ship:
     dw $D8B0, $7000  ; Doors
     dw $D8B2, $2C01  ; Doors
     dw $D8B6, $3008  ; Doors
+    dw #$FFFF
+
+preset_rando_upper_norfair_speedless_speedway:
+    dw #preset_rando_upper_norfair_crumble_shaft_up
+    dw $078D, $97E6  ; DDB
+    dw $079B, $AF72  ; MDB
+    dw $090F, $1000  ; Screen subpixel X position
+    dw $0913, $FC00  ; Screen subpixel Y position
+    dw $09A6, $0007  ; Equipped Beams
+    dw $09A8, $0007  ; Collected Beams
+    dw $09C2, $018F  ; Health
+    dw $09C4, $018F  ; Max health
+    dw $09CA, $0005  ; Supers
+    dw $09CE, $0005  ; Pbs
+    dw $D8B8, $0E00  ; Doors
     dw #$FFFF
 
 preset_nghyper_norfair_postridley_three_musketeers:
@@ -8903,6 +8914,16 @@ preset_gtclassic_kraids_lair_leaving_varia:
     dw $D8B6, $3008  ; Doors
     dw #$FFFF
 
+preset_gtmax_kraids_lair_kraid_kihunters:
+    dw #preset_gtclassic_kraids_lair_kraid_kihunters
+    dw $0913, $8000  ; Screen subpixel Y position
+    dw $09C2, $004B  ; Health
+    dw $09C4, $0063  ; Max health
+    dw $09C6, $0002  ; Missiles
+    dw $09CA, $0002  ; Supers
+    dw $D870, $0080  ; Items
+    dw #$FFFF
+
 preset_rando_upper_norfair_bubble_mountain_dboost:
     dw #preset_rando_upper_norfair_ice_hellrun
     dw $078D, $958E  ; DDB
@@ -8918,31 +8939,6 @@ preset_rando_upper_norfair_bubble_mountain_dboost:
     dw $0AFA, $018B  ; Samus Y
     dw $D8B8, $0E00  ; Doors
     dw $D8BA, $0010  ; Doors
-    dw #$FFFF
-
-preset_gtmax_kraids_lair_kraid_kihunters:
-    dw #preset_gtclassic_kraids_lair_kraid_kihunters
-    dw $0913, $8000  ; Screen subpixel Y position
-    dw $09C2, $004B  ; Health
-    dw $09C4, $0063  ; Max health
-    dw $09C6, $0002  ; Missiles
-    dw $09CA, $0002  ; Supers
-    dw $D870, $0080  ; Items
-    dw #$FFFF
-
-preset_rando_upper_norfair_norfair_reserve_2tank:
-    dw #preset_rando_upper_norfair_crumble_shaft_up
-    dw $078D, $953A  ; DDB
-    dw $079B, $ACB3  ; MDB
-    dw $090F, $2001  ; Screen subpixel X position
-    dw $0913, $2C02  ; Screen subpixel Y position
-    dw $09CA, $0005  ; Supers
-    dw $09CE, $0005  ; Pbs
-    dw $0A1C, $0002  ; Samus position/state
-    dw $0A1E, $0004  ; More position/state
-    dw $0AF6, $004E  ; Samus X
-    dw $D8B8, $0E00  ; Doors
-    dw $D8BA, $0018  ; Doors
     dw #$FFFF
 
 preset_suitless_xray_blue_brin_hoppers:
@@ -9014,19 +9010,6 @@ preset_rbo_shopping_single_maridia_leaving_speed_farm_2:
     dw $D8B6, $B00C  ; Doors
     dw #$FFFF
 
-preset_rando_upper_norfair_norfair_reserve_room:
-    dw #preset_rando_upper_norfair_norfair_reserve_2tank
-    dw $078D, $9552  ; DDB
-    dw $079B, $AC83  ; MDB
-    dw $090F, $7000  ; Screen subpixel X position
-    dw $0913, $9800  ; Screen subpixel Y position
-    dw $09C2, $00E9  ; Health
-    dw $09C6, $000F  ; Missiles
-    dw $09C8, $000F  ; Max missiles
-    dw $0AF6, $0045  ; Samus X
-    dw $D876, $8000  ; Items
-    dw #$FFFF
-
 preset_ngplasma_norfair_postridley_fireflea_room:
     dw #preset_nghyper_norfair_postridley_fireflea_room
     dw $090F, $7E00  ; Screen subpixel X position
@@ -9038,6 +9021,21 @@ preset_ngplasma_norfair_postridley_fireflea_room:
     dw $0A76, $0000  ; Hyper beam
     dw $0AF6, $00A5  ; Samus X
     dw $0AF8, $4FFF  ; Samus subpixel X
+    dw #$FFFF
+
+preset_rando_upper_norfair_norfair_reserve_2tank:
+    dw #preset_rando_upper_norfair_crumble_shaft_up
+    dw $078D, $953A  ; DDB
+    dw $079B, $ACB3  ; MDB
+    dw $090F, $2001  ; Screen subpixel X position
+    dw $0913, $2C02  ; Screen subpixel Y position
+    dw $09CA, $0005  ; Supers
+    dw $09CE, $0005  ; Pbs
+    dw $0A1C, $0002  ; Samus position/state
+    dw $0A1E, $0004  ; More position/state
+    dw $0AF6, $004E  ; Samus X
+    dw $D8B8, $0E00  ; Doors
+    dw $D8BA, $0018  ; Doors
     dw #$FFFF
 
 preset_ngplasma_norfair_postridley_springball_maze:
@@ -9103,6 +9101,19 @@ preset_14speed_upper_norfair_precathedral:
     dw $D874, $0904  ; Items
     dw $D876, $0001  ; Items
     dw $D8B8, $00EF  ; Doors
+    dw #$FFFF
+
+preset_rando_upper_norfair_norfair_reserve_room:
+    dw #preset_rando_upper_norfair_norfair_reserve_2tank
+    dw $078D, $9552  ; DDB
+    dw $079B, $AC83  ; MDB
+    dw $090F, $7000  ; Screen subpixel X position
+    dw $0913, $9800  ; Screen subpixel Y position
+    dw $09C2, $00E9  ; Health
+    dw $09C6, $000F  ; Missiles
+    dw $09C8, $000F  ; Max missiles
+    dw $0AF6, $0045  ; Samus X
+    dw $D876, $8000  ; Items
     dw #$FFFF
 
 preset_allbosspkdr_upper_norfair_business_center_revisit:
@@ -9367,22 +9378,6 @@ preset_gtclassic_kraids_lair_minikraid_revisit:
     dw $D8B8, $00E4  ; Doors
     dw #$FFFF
 
-preset_rando_upper_norfair_speed_booster_return:
-    dw #preset_rando_upper_norfair_norfair_reserve_2tank
-    dw $078D, $95B2  ; DDB
-    dw $079B, $AD1B  ; MDB
-    dw $07F5, $0003  ; Music Track
-    dw $090F, $D800  ; Screen subpixel X position
-    dw $0913, $4800  ; Screen subpixel Y position
-    dw $09C2, $00D6  ; Health
-    dw $09C4, $018F  ; Max health
-    dw $09CA, $0004  ; Supers
-    dw $0AF6, $00A9  ; Samus X
-    dw $0AFA, $007B  ; Samus Y
-    dw $D878, $0004  ; Items
-    dw $D8BA, $0030  ; Doors
-    dw #$FFFF
-
 preset_suitless_xray_noob_bridge:
     dw #preset_suitless_xray_green_hill_zone_revisit
     dw $078D, $8E9E  ; DDB
@@ -9402,6 +9397,22 @@ preset_suitless_xray_noob_bridge:
     dw $0AF8, $CFFF  ; Samus subpixel X
     dw $0AFA, $03AB  ; Samus Y
     dw $D872, $CFEF  ; Items
+    dw #$FFFF
+
+preset_rando_upper_norfair_speed_booster_return:
+    dw #preset_rando_upper_norfair_norfair_reserve_2tank
+    dw $078D, $95B2  ; DDB
+    dw $079B, $AD1B  ; MDB
+    dw $07F5, $0003  ; Music Track
+    dw $090F, $D800  ; Screen subpixel X position
+    dw $0913, $4800  ; Screen subpixel Y position
+    dw $09C2, $00D6  ; Health
+    dw $09C4, $018F  ; Max health
+    dw $09CA, $0004  ; Supers
+    dw $0AF6, $00A9  ; Samus X
+    dw $0AFA, $007B  ; Samus Y
+    dw $D878, $0004  ; Items
+    dw $D8BA, $0030  ; Doors
     dw #$FFFF
 
 preset_rbo_shopping_double_maridia_nutella_refill:
@@ -17771,7 +17782,6 @@ preset_rando_tourian_mother_brain_all_missiles:
     dw $0AF6, $00CA  ; Samus X
     dw $0AFA, $009B  ; Samus Y
     dw $D820, $0405  ; Events
-    dw $D82C, $0203  ; Bosses
     dw #$FFFF
 
 preset_nodropskpdr_maridia_halfie_setup:
@@ -18390,6 +18400,7 @@ preset_rando_tourian_zebes_escape:
     dw $0AF6, $0025  ; Samus X
     dw $0AFA, $00C3  ; Samus Y
     dw $D820, $4405  ; Events
+    dw $D82C, $0203  ; Bosses
     dw #$FFFF
 
 preset_nodropskpdr_maridia_draygon:

--- a/src/presets/combined_preset_data.asm
+++ b/src/presets/combined_preset_data.asm
@@ -16502,10 +16502,12 @@ preset_rando_tourian_metroids_1:
     dw $09CE, $000F  ; Pbs
     dw $09D0, $000F  ; Max pbs
     dw $09D2, $0003  ; Currently selected item
-    dw $D820, $0401  ; Events
-    dw $D828, $0100  ; Bosses
-    dw $D82A, $0100  ; Bosses
+    dw $D820, $0FC1  ; Events
+    dw $D822, $0020  ; Events
+    dw $D828, $0104  ; Bosses
+    dw $D82A, $0101  ; Bosses
     dw $D82C, $0003  ; Bosses
+    dw $D82E, $0001  ; Bosses
     dw $D872, $1400  ; Items
     dw $D8B2, $6C00  ; Doors
     dw $D8B4, $0000  ; Doors
@@ -16918,7 +16920,7 @@ preset_rando_tourian_metroids_2:
     dw $09CC, $003C  ; Max supers
     dw $09CE, $000C  ; Pbs
     dw $0AFA, $008B  ; Samus Y
-    dw $D822, $0001  ; Events
+    dw $D822, $0021  ; Events
     dw $D8C4, $0001  ; Doors
     dw #$FFFF
 
@@ -16939,7 +16941,7 @@ preset_rando_tourian_metroids_3:
     dw $0A1E, $1508  ; More position/state
     dw $0AF6, $00DB  ; Samus X
     dw $0AFA, $018B  ; Samus Y
-    dw $D822, $0003  ; Events
+    dw $D822, $0023  ; Events
     dw $D8C4, $0003  ; Doors
     dw #$FFFF
 
@@ -17180,7 +17182,7 @@ preset_rando_tourian_metroids_4:
     dw $0A1C, $0089  ; Samus position/state
     dw $0A1E, $1508  ; More position/state
     dw $0AF6, $05DB  ; Samus X
-    dw $D822, $0007  ; Events
+    dw $D822, $0027  ; Events
     dw $D8C4, $0007  ; Doors
     dw #$FFFF
 
@@ -17203,7 +17205,7 @@ preset_rando_tourian_blue_hoppers:
     dw $0A1E, $0004  ; More position/state
     dw $0AF6, $00B5  ; Samus X
     dw $0AFA, $01CB  ; Samus Y
-    dw $D822, $000F  ; Events
+    dw $D822, $002F  ; Events
     dw $D8C4, $000F  ; Doors
     dw #$FFFF
 
@@ -17779,9 +17781,9 @@ preset_rando_tourian_mother_brain_all_missiles:
     dw $09CA, $0000  ; Supers
     dw $09CC, $000A  ; Max supers
     dw $09D2, $0001  ; Currently selected item
-    dw $0AF6, $00CA  ; Samus X
+    dw $0AF6, $00CF  ; Samus X
     dw $0AFA, $009B  ; Samus Y
-    dw $D820, $0405  ; Events
+    dw $D820, $0FC5  ; Events
     dw #$FFFF
 
 preset_nodropskpdr_maridia_halfie_setup:

--- a/src/presets/combined_preset_names.asm
+++ b/src/presets/combined_preset_names.asm
@@ -1,6 +1,6 @@
 
-warnpc $EFBEE5
-org $EFBEE5
+warnpc $EFBED7
+org $EFBED7
 print pc, " preset names start"
 
 preset_names:
@@ -2323,6 +2323,9 @@ preset_names_ridley_etank:
 
 preset_names_ridley_farming_room:
     db "Ridley Farming Room", #$FF
+
+preset_names_ridley_loaded:
+    db "Ridley Loaded", #$FF
 
 preset_names_ridley_low_hp:
     db "Ridley Low HP", #$FF

--- a/src/presets/prkd19_data.asm
+++ b/src/presets/prkd19_data.asm
@@ -1463,7 +1463,6 @@ preset_prkd19_lower_norfair_leaving_ridley:
     dw $0919, $00D7  ; Layer 2 Y position
     dw $09C6, $0004  ; Missiles
     dw $09CA, $0003  ; Supers
-    dw $09CE, $0005  ; Pbs
     dw $0A1C, $0001  ; Samus position/state
     dw $0A1E, $0008  ; More position/state
     dw $0AF6, $005F  ; Samus X

--- a/src/presets/prkd20_data.asm
+++ b/src/presets/prkd20_data.asm
@@ -1464,7 +1464,6 @@ preset_prkd20_lower_norfair_leaving_ridley:
     dw $0919, $00D7  ; Layer 2 Y position
     dw $09C6, $0004  ; Missiles
     dw $09CA, $0003  ; Supers
-    dw $09CE, $0005  ; Pbs
     dw $0A1C, $0001  ; Samus position/state
     dw $0A1E, $0008  ; More position/state
     dw $0AF6, $005F  ; Samus X
@@ -2380,7 +2379,6 @@ preset_prkd20_backtracking_parlor_return:
     dw $07F3, $000C  ; Music Bank
     dw $07F5, $0005  ; Music Track
     dw $0911, $05E3  ; Screen X position in pixels
-    dw $0913, $0000  ; Screen subpixel Y position
     dw $0915, $0400  ; Screen Y position in pixels
     dw $0917, $02F1  ; Layer 2 X position
     dw $09C6, $0010  ; Missiles

--- a/src/presets/rando_data.asm
+++ b/src/presets/rando_data.asm
@@ -2580,9 +2580,12 @@ preset_rando_tourian_metroids_1:
     dw $09D0, $000F  ; Max pbs
     dw $09D2, $0003  ; Currently selected item
     dw $0AFA, $038B  ; Samus Y
-    dw $D820, $0401  ; Events
-    dw $D828, $0100  ; Bosses
+    dw $D820, $0FC1  ; Events
+    dw $D822, $0020  ; Events
+    dw $D828, $0104  ; Bosses
+    dw $D82A, $0101  ; Bosses
     dw $D82C, $0003  ; Bosses
+    dw $D82E, $0001  ; Bosses
     dw $D870, $00A0  ; Items
     dw $D8B0, $0000  ; Doors
     dw $D8B2, $6C00  ; Doors
@@ -2605,7 +2608,7 @@ preset_rando_tourian_metroids_2:
     dw $09CC, $003C  ; Max supers
     dw $09CE, $000C  ; Pbs
     dw $0AFA, $008B  ; Samus Y
-    dw $D822, $0001  ; Events
+    dw $D822, $0021  ; Events
     dw $D8C4, $0001  ; Doors
     dw #$FFFF
 
@@ -2626,7 +2629,7 @@ preset_rando_tourian_metroids_3:
     dw $0A1E, $1508  ; More position/state
     dw $0AF6, $00DB  ; Samus X
     dw $0AFA, $018B  ; Samus Y
-    dw $D822, $0003  ; Events
+    dw $D822, $0023  ; Events
     dw $D8C4, $0003  ; Doors
     dw #$FFFF
 
@@ -2648,7 +2651,7 @@ preset_rando_tourian_metroids_4:
     dw $09CE, $0006  ; Pbs
     dw $0AF6, $05DB  ; Samus X
     dw $0AFA, $008B  ; Samus Y
-    dw $D822, $0007  ; Events
+    dw $D822, $0027  ; Events
     dw $D8C4, $0007  ; Doors
     dw #$FFFF
 
@@ -2673,7 +2676,7 @@ preset_rando_tourian_blue_hoppers:
     dw $0A1E, $0004  ; More position/state
     dw $0AF6, $00B5  ; Samus X
     dw $0AFA, $01CB  ; Samus Y
-    dw $D822, $000F  ; Events
+    dw $D822, $002F  ; Events
     dw $D8C4, $000F  ; Doors
     dw #$FFFF
 
@@ -2785,9 +2788,9 @@ preset_rando_tourian_mother_brain_all_missiles:
     dw $09CA, $0000  ; Supers
     dw $09CC, $000A  ; Max supers
     dw $09D2, $0001  ; Currently selected item
-    dw $0AF6, $00CA  ; Samus X
+    dw $0AF6, $00CF  ; Samus X
     dw $0AFA, $009B  ; Samus Y
-    dw $D820, $0405  ; Events
+    dw $D820, $0FC5  ; Events
     dw #$FFFF
 
 preset_rando_tourian_mother_brain_all_supers:

--- a/src/presets/rando_data.asm
+++ b/src/presets/rando_data.asm
@@ -1103,7 +1103,7 @@ preset_rando_four_bosses_xray_climb:
     dw $D8C2, $4D00  ; Doors
     dw #$FFFF
 
-preset_rando_four_bosses_ridley_30_25_5_ammo:
+preset_rando_four_bosses_ridley_loaded:
     dw #preset_rando_four_bosses_xray_climb ; Four Bosses: X-Ray Climb
     dw $078D, $995A  ; DDB
     dw $079B, $B37A  ; MDB
@@ -1113,16 +1113,16 @@ preset_rando_four_bosses_ridley_30_25_5_ammo:
     dw $0911, $0000  ; Screen X position in pixels
     dw $0913, $A400  ; Screen subpixel Y position
     dw $0917, $0000  ; Layer 2 X position
-    dw $09A2, $1005  ; Equipped Items
-    dw $09A4, $1005  ; Collected Items
-    dw $09A6, $0000  ; Equipped Beams
-    dw $09A8, $0000  ; Collected Beams
+    dw $09A2, $F32F  ; Equipped Items
+    dw $09A4, $F32F  ; Collected Items
+    dw $09A6, $100F  ; Equipped Beams
+    dw $09A8, $100F  ; Collected Beams
     dw $09C2, $0257  ; Health
     dw $09C4, $0257  ; Max health
     dw $09C6, $001E  ; Missiles
     dw $09C8, $001E  ; Max missiles
-    dw $09CA, $0019  ; Supers
-    dw $09CC, $0019  ; Max supers
+    dw $09CA, $001E  ; Supers
+    dw $09CC, $001E  ; Max supers
     dw $09CE, $0005  ; Pbs
     dw $09D0, $0005  ; Max pbs
     dw $0A1C, $008A  ; Samus position/state
@@ -1136,6 +1136,16 @@ preset_rando_four_bosses_ridley_30_25_5_ammo:
     dw $D8BC, $0001  ; Doors
     dw $D8C0, $0000  ; Doors
     dw $D8C2, $0000  ; Doors
+    dw #$FFFF
+
+preset_rando_four_bosses_ridley_30_25_5_ammo:
+    dw #preset_rando_four_bosses_ridley_loaded ; Four Bosses: Ridley Loaded
+    dw $09A2, $1005  ; Equipped Items
+    dw $09A4, $1005  ; Collected Items
+    dw $09A6, $0000  ; Equipped Beams
+    dw $09A8, $0000  ; Collected Beams
+    dw $09CA, $0019  ; Supers
+    dw $09CC, $0019  ; Max supers
     dw #$FFFF
 
 preset_rando_four_bosses_ridley_10_20_15_ammo:
@@ -2778,7 +2788,6 @@ preset_rando_tourian_mother_brain_all_missiles:
     dw $0AF6, $00CA  ; Samus X
     dw $0AFA, $009B  ; Samus Y
     dw $D820, $0405  ; Events
-    dw $D82C, $0203  ; Bosses
     dw #$FFFF
 
 preset_rando_tourian_mother_brain_all_supers:
@@ -2808,6 +2817,7 @@ preset_rando_tourian_zebes_escape:
     dw $0AF6, $0025  ; Samus X
     dw $0AFA, $00C3  ; Samus Y
     dw $D820, $4405  ; Events
+    dw $D82C, $0203  ; Bosses
     dw #$FFFF
 
 preset_rando_tourian_escape_room_3:

--- a/src/presets/rando_menu.asm
+++ b/src/presets/rando_menu.asm
@@ -136,6 +136,7 @@ presets_submenu_rando_four_bosses:
     dw #presets_rando_four_bosses_grapple_escape_hijumpless
     dw #presets_rando_four_bosses_double_springball_jump
     dw #presets_rando_four_bosses_xray_climb
+    dw #presets_rando_four_bosses_ridley_loaded
     dw #presets_rando_four_bosses_ridley_30_25_5_ammo
     dw #presets_rando_four_bosses_ridley_10_20_15_ammo
     dw #presets_rando_four_bosses_ridley_low_hp
@@ -464,6 +465,9 @@ presets_rando_four_bosses_double_springball_jump:
 
 presets_rando_four_bosses_xray_climb:
     %cm_preset("X-Ray Climb", #preset_names_xray_climb, #preset_rando_four_bosses_xray_climb)
+
+presets_rando_four_bosses_ridley_loaded:
+    %cm_preset("Ridley Loaded", #preset_names_ridley_loaded, #preset_rando_four_bosses_ridley_loaded)
 
 presets_rando_four_bosses_ridley_30_25_5_ammo:
     %cm_preset("Ridley 30+25+5 Ammo", #preset_names_ridley_30_25_5_ammo, #preset_rando_four_bosses_ridley_30_25_5_ammo)

--- a/src/ramwatchmenu.asm
+++ b/src/ramwatchmenu.asm
@@ -482,6 +482,7 @@ ramwatch_common_proj_1C1D:
 RAMWatchCommonMiscMenu:
     dw ramwatch_common_misc_05E5
     dw ramwatch_common_misc_079B
+    dw ramwatch_common_misc_07A5
     dw ramwatch_common_misc_0998
     dw ramwatch_common_misc_09DA
     dw ramwatch_common_misc_09DC
@@ -499,6 +500,9 @@ ramwatch_common_misc_05E5:
 
 ramwatch_common_misc_079B:
     %cm_jsl("Room ID", action_select_common_address, #!ROOM_ID)
+
+ramwatch_common_misc_07A5:
+    %cm_jsl("Room Width Blocks", action_select_common_address, #!ROOM_WIDTH_BLOCKS)
 
 ramwatch_common_misc_0998:
     %cm_jsl("Game State", action_select_common_address, #!GAMEMODE)

--- a/web/data/changelog.mdx
+++ b/web/data/changelog.mdx
@@ -44,6 +44,8 @@
 - Add more Botwoon first pattern RNG options and option to disable fast teleport (2.7.5)
 - Added 03D6 address to any% glitched RAM watch common addresses (2.7.5.1)
 - Small RAM watch adjustments and fix temperamental OOB tile viewer X-ray collection (2.7.5.2)
+- Rando preset updates and vertical speed now shows 1/256 pixels instead of 1/16 (2.7.5.3)
+- Added RAM watch common address and door skip displays $1842 value after block shuffler (2.7.5.3)
 
 # Version 2.6.x
 - Optimize kraid rock projectiles to reduce lag when Kraid rises (2.6.0)

--- a/web/data/config.json
+++ b/web/data/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Super Metroid Practice Hack",
-    "version": "2.7.5.2",
+    "version": "2.7.5.3",
     "variants": ["NTSC", "PAL"],
     "base": {
         "NTSC": {

--- a/web/data/infohudmode.mdx
+++ b/web/data/infohudmode.mdx
@@ -90,7 +90,7 @@ Displays the horizontal speed combined with momentum in pixels and 1/16th pixels
 Displays the horizontal speed (without momentum) in pixels and 1/16th pixels (subpixels).
 
 ## Vertical Speed
-Displays the vertical speed in pixels and 1/16th pixels (subpixels), except in the case where speed is negative during a moonfall.
+Displays the vertical speed in pixels and 1/256th pixels (subpixels), except in the case where speed is negative during a moonfall.
 The negative moonfall speed is still displayed as positive, so it starts at 65535 (0xFFFF) and decreases as Samus' moonfall speed increases.
 Also initial jump speed will displayed as a three digit hex value overwriting the item collection percentage, and Samus HP will be overwritten with space jump feedback:
 &nbsp;  
@@ -219,7 +219,8 @@ Last two characters = Feedback on breaking out of the aim down pose:
 - L1 indicates you broke pose one frame late. You will get this feedback just as you hit the door transition.
 - LX indicates you broke pose more than one frame late. You will not get this feedback until after the door transition.
 
-Additionally Samus HP will be overwritten with the number of PLMs.
+Additionally Samus HP will be overwritten with the number of PLMs, and when a block shuffler is touched,
+the aforementioned feedback will be overwritten by the $1842 RAM value since this value affects the any% glitched route.
 
 ## Taco Tank
 Provides feedback on attempts to collect the Retro Brinstar E-Tank using a precise walljump:  


### PR DESCRIPTION
Received a couple of simple requests.  Also including a RAM watch common address.  I also want to adjust the door skip infohud mode to show the $1842 value when you hit the block shuffler.  Just need to do that and some testing, hoping to release later today.