### PR TITLE
Make some RNG calls after rerandomizing

### DIFF
--- a/src/save.asm
+++ b/src/save.asm
@@ -109,6 +109,13 @@ post_load_state:
     JSL MenuRNG ; rerandomize hack RNG
 
   .randomizeOnLoad
+    ; Make some RNG calls in case we're in a weird XBA state.
+    LDX #$0008
+  .rerandomize_loop
+    JSL $808111
+    DEX
+    BNE .rerandomize_loop
+
     ; Randomize energy/ammo?
     LDA !sram_loadstate_rando_enable : BEQ .init_wram
     JSL RandomizeOnLoad

--- a/src/tinystates.asm
+++ b/src/tinystates.asm
@@ -148,6 +148,13 @@ post_load_state:
     JSL MenuRNG ; rerandomize hack RNG
 
   .randomizeOnLoad
+    LDX #$0008
+    ; Make some RNG calls in case we're in a weird XBA state.
+  .rerandomize_loop
+    JSL $808111
+    DEX
+    BNE .rerandomize_loop
+
     ; Randomize energy/ammo?
     LDA !sram_loadstate_rando_enable : BEQ .init_wram
     JSL RandomizeOnLoad


### PR DESCRIPTION
This PR adds 8 RNG calls upon loading a savestate with rerandomize enabled. This is to try to break up patterns in case the game is in a weird RNG state caused by being in an XBA room that is doing a few predictable RNG calls every frame.

This intentionally has no effect on RNG loops outside of XBA rooms. Getting stuck in one of those loops involves visiting an XBA room for a specific period of time to move out of the main loop another RNG loop. Once in such a loop, further RNG calls will remain in the loop until visiting a room with XBA or with an enemy that reseeds RNG. We leave these alone in case someone is practicing a manip that involves intentionally getting stuck in an RNG loop. The type of RNG states this is intended to address are more transient, less-understood, and only exist while actively inside an XBA room.

Added because Zeni thought Ridley was having a tendency to get stuck in weird patterns even with rerandomize turned on; he has been testing this patch for a bit and hasn't reported seeing this behavior since. It may have just been confirmation bias, but if it is a real effect the only possible explanation I can think of is weird XBA states. So this patch might not actually do anything, but it can't *hurt*.