### PR TITLE
Clear BG1 VRAM when loading presets to improve screen-shake artifacts

### DIFF
--- a/src/main.asm
+++ b/src/main.asm
@@ -17,7 +17,7 @@ lorom
 !VERSION_MAJOR = 2
 !VERSION_MINOR = 7
 !VERSION_BUILD = 9
-!VERSION_REV   = 0
+!VERSION_REV   = 1
 
 table ../resources/normal.tbl
 print ""

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -559,6 +559,9 @@ category_preset_load:
     BRA .loadValue
 }
 
+preset_clear_bg1_vram_fillword:
+    dw #$0323
+
 ; This method is very similar to $80A07B (start gameplay)
 preset_start_gameplay:
 {
@@ -741,6 +744,17 @@ endif
   .clearFXPaletteLoop
     STZ !PALETTE_FX_ID,X
     DEX #2 : BPL .clearFXPaletteLoop
+
+    ; Reset BG1 VRAM
+    %a8()
+    LDA #$80 : STA $2115
+    LDX #$5000 : STX $2116
+    LDX #$1000 : STX $4315
+    LDX #$1809 : STX $4310
+    LDX #preset_clear_bg1_vram_fillword : STX $4312
+    LDA.b #preset_clear_bg1_vram_fillword>>16 : STA $4314
+    LDA #$02 : STA $420B
+    %a16()
 
     JSL Randomize_Preset_Equipment
     JSL $90AC8D ; Update beam graphics

--- a/web/data/changelog.mdx
+++ b/web/data/changelog.mdx
@@ -63,6 +63,7 @@
 - Add map rando patches option with aim anywhere and patches blue echoes sound queue bug (2.7.9)
 - Rerandomize on load now runs extra RNG calls (2.7.9)
 - Update timers routine optimized and accounted for by artificial lag (2.7.9)
+- Clear BG1 VRAM when loading presets to improve screen-shake artifacts (2.7.9.1)
 
 # Version 2.6.x
 - Optimize kraid rock projectiles to reduce lag when Kraid rises (2.6.0)

--- a/web/data/config.json
+++ b/web/data/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Super Metroid Practice Hack",
-    "version": "2.7.9",
+    "version": "2.7.9.1",
     "variants": ["NTSC", "PAL"],
     "base": {
         "NTSC": {

--- a/web/data/help.mdx
+++ b/web/data/help.mdx
@@ -157,14 +157,16 @@ If you experience crashes or severe glitches when using savestates, your platfor
 | - OoB Show X Wraparound       | When OoB tile viewer enabled, this shows an extra set of tiles that Samus can interact with along the Y axis where X can jump from 0 to -1 (FFFF), which the game treats as a large number for collision purposes.
 |&nbsp;|
 | **Room Layout**               | Modify the room layout, usually to help practice rando scenarios.
+| - Map Rando Patches           | Room modifications as you would see in a map randomizer. Allows aim anywhere and also patches blue echoes sound queue bug.
+| - Area Rando Patches          | Room modifications as you would see in a VARIA area randomizer.
+| - Anti-Softlock Patches       | Room modifications as you would see in a typical VARIA randomizer.
+| - DASH Recall Patches         | Room modifications as you would see in a DASH Recall randomizer.
+| - VARIA Tweaks                | Room modifications as you would see with VARIA tweaks enabled.
 | - Item Pickups                | Option to replace all items with a specific item.  Can also be done by icon type (visible, chozo orb, hidden).
+| - Less Common Patches         | Submenu for the three room modifications below.
 | - Bomb Torizo Door            | Control Bomb Torizo Door oscillator, whether door waits 40 (fast) or 41 (slow) frames before closing after collecting bombs.
 | - Remove Steam Collision      | Makes Ceres and Zebes escape steam intangible, and also changes the color of the steam indicating this option is enabled.
 | - Remove Magnet Stairs        | Adds slope tiles to prevent the magnet stairs effect, and also modifies the stair decoration indicating this option is enabled.
-| - Area Rando Patches          | Room modifications as you would see in a VARIA area randomizer.
-| - Anti-Softlock Patches       | Room modifications as you would see in a typical VARIA randomizer.
-| - VARIA Tweaks                | Room modifications as you would see with VARIA tweaks enabled.
-| - DASH Recall Patches         | Room modifications as you would see in a DASH Recall randomizer.
 | - Custom Door Portal          | Sets one pair of doors connected to each other as you might see in an area or boss randomizer or in a map randomizer.
 |                               | Note: This mode is not recommended if intentionally triggering out-of-bounds door transitions.
 | - Door Portal I-Frames        | Option to give Samus 128 invulnerability frames when she goes through the custom portal.


### PR DESCRIPTION
If you start practice hack and jump to a preset (this was reported in business center so testing there) and fire a super missile into the wall, you'll notice the screen shake produces an ugly white dashed line along the left side of the room.  This is not present in vanilla.  If you move to a different room and come back, it improves.  If you move to a different room and then load the same preset, it also (generally) improves.  If you reset console (soft or hard reset) and load preset, the white dashed line returns.

I believe screen-shake is causing the camera to show areas of VRAM that are not initialized yet because the camera hasn't moved to show them.  This has probably been an issue for a long time in the practice hack.  A suggestion was made to clear out the VRAM using a value of $323 (I guess that's a blank/black value in the CRE tilemap).  This suggestion does seem to work.  It might not be perfect in rooms that don't use CRE like Kraid (I haven't tested there; I just finished this and am posting it).  Theoretically it's ready to push but I'll give this some time for review and testing.  If someone here agrees with the change and tests it and wants to push it sooner that's fine with me.