### PR TITLE
Avoid saving to SRAM when loading preset or savestate

### DIFF
--- a/src/cutscenes.asm
+++ b/src/cutscenes.asm
@@ -1837,7 +1837,7 @@ else
 org $A98C05
 endif
     JMP cutscenes_mb_first_earthquake_start
-    BRA $02
+    BRA $02 : NOP #2
 cutscenes_mb_first_earthquake_end:
 
 if !FEATURE_PAL

--- a/src/defines.asm
+++ b/src/defines.asm
@@ -402,9 +402,6 @@
 !ram_cm_selected_slot = !WRAM_MENU_START+$92
 !ram_cm_preset_elevator = !WRAM_MENU_START+$94
 
-; keyboard used by both presets and customize menus
-!ram_cm_keyboard_buffer = !WRAM_MENU_START+$B8 ; $18 bytes
-
 !ram_cm_custompalette_blue = !WRAM_MENU_START+$90
 !ram_cm_custompalette_green = !WRAM_MENU_START+$92
 !ram_cm_custompalette_red = !WRAM_MENU_START+$94
@@ -414,13 +411,25 @@
 !ram_cm_dummy_off = !WRAM_MENU_START+$AC
 !ram_cm_dummy_num = !WRAM_MENU_START+$AE
 
+; keyboard used by both presets and customize menus
+!ram_cm_keyboard_buffer = !WRAM_MENU_START+$B8 ; $18 bytes
+
 ; ^ FREE SPACE ^ up to +$CE
 ; Note: +$B8 to +$CE range also used as frames held counters and keyboard buffer
 ;       and is reset to zero when loading a savestate
 
-; Reserve 48 bytes for CGRAM cache
-; Currently first 32 bytes plus last 2 bytes are used
-!ram_cgram_cache = !WRAM_MENU_START+$D0 ; $30 bytes
+; load state cannot be initiated from the menu, so it can overlap cgram
+!ram_loadstate_music_data = !WRAM_MENU_START+$D0
+!ram_loadstate_music_track = !WRAM_MENU_START+$D2
+!ram_loadstate_sound_timer = !WRAM_MENU_START+$D4
+!ram_loadstate_cached_random_number = !WRAM_MENU_START+$D6
+!ram_loadstate_frame_counter = !WRAM_MENU_START+$D8
+!ram_loadstate_enemy_main_loop_counter = !WRAM_MENU_START+$DA
+!ram_cgram_cache = !WRAM_MENU_START+$D0 ; $20 bytes
+
+!ram_backup_message_box = !WRAM_MENU_START+$F0
+
+; ^ FREE SPACE ^ up to +$FE
 
 
 ; -----------------
@@ -636,11 +645,6 @@
 !sram_custom_header_tinystates = !SRAM_START+$E18 ; $18 bytes
 !sram_custom_preset_safewords_tinystates = !SRAM_START+$E30 ; $20 bytes
 !sram_custom_preset_names_tinystates = !SRAM_START+$E50 ; $180 bytes
-
-; SM specific things
-!SRAM_MUSIC_DATA = !SRAM_START+$FD0
-!SRAM_MUSIC_TRACK = !SRAM_START+$FD2
-!SRAM_SOUND_TIMER = !SRAM_START+$FD4
 
 ; ^ FREE SPACE ^ up to +$FFE
 
@@ -1182,8 +1186,9 @@
 !CATEGORY_PRESET_STACK_SIZE        = #$0800
 !eram_category_preset_stack        = !ENEMY_ID
 
+!BG3_HDMA_CHANNELS_BACKUP = $7E33EA
 !HUD_TILEMAP = $7EC600
-!MAP_COUNTER = $7ECAE8 ; Not used in vanilla
+!MAP_COUNTER = $7ECAE8  ; Not used in vanilla
 !SCROLLS = $7ECD20
 !MAP_TILES_EXPLORED_CRATERIA = $7ECD52
 !MAP_TILES_EXPLORED_BRINSTAR = $7ECE52
@@ -1260,26 +1265,18 @@ if !FEATURE_TINYSTATES
 !SRAM_DMA_BANK = $737000
 !SRAM_SAVED_SP = $737F00
 !SRAM_SAVED_STATE = $737F02
-!SRAM_SAVED_RNG = $737F80
-!SRAM_SAVED_FRAME_COUNTER = $737F82
-!SRAM_SAVED_ENEMY_COUNTER = $737F84
 !SRAM_SAVED_MINIMAP = $737F86
 !SRAM_SEG_TIMER_F = $737F88
 !SRAM_SEG_TIMER_S = $737F8A
 !SRAM_SEG_TIMER_M = $737F8C
-!SRAM_SLOWDOWN_MODE = $737F8E
 else
 !SRAM_DMA_BANK = $770000
-!SRAM_SAVED_RNG = $770080
-!SRAM_SAVED_FRAME_COUNTER = $770082
-!SRAM_SAVED_ENEMY_COUNTER = $770084
 !SRAM_SAVED_SP = $774004
 !SRAM_SAVED_STATE = $774006
 !SRAM_SAVED_MINIMAP = $774008
 !SRAM_SEG_TIMER_F = $77400A
 !SRAM_SEG_TIMER_S = $77400C
 !SRAM_SEG_TIMER_M = $77400E
-!SRAM_SLOWDOWN_MODE = $774010
 endif
 endif
 

--- a/src/freespace.asm
+++ b/src/freespace.asm
@@ -254,7 +254,7 @@ endif
 !END_FREESPACE_E3 = $E30000+$10000
 !END_FREESPACE_E4 = $E40000+$10000
 !END_FREESPACE_E5 = $E58000 ; roomnames.asm
-!END_FREESPACE_E6 = $E68000 ; tilegraphics.asm
+!END_FREESPACE_E6 = $E68800 ; tilegraphics.asm
 !END_FREESPACE_E7 = $E78000 ; tilegraphics.asm
 !END_FREESPACE_E8 = $E88000 ; tilegraphics.asm + presets.asm
 !END_FREESPACE_E9 = $E98000 ; presets.asm
@@ -382,7 +382,7 @@ macro printfreespace()
 %tickfreespace(E3)
 %tickfreespace(E4)
 ;%tickfreespace(E5) roomnames.asm
-;%tickfreespace(E6) tilegraphics.asm
+%tickfreespace(E6)
 ;%tickfreespace(E7) tilegraphics.asm
 ;%tickfreespace(E8) tilegraphics.asm + presets.asm
 ;%tickfreespace(E9) presets.asm

--- a/src/menu.asm
+++ b/src/menu.asm
@@ -19,7 +19,7 @@ incsrc mainmenu.asm
 %startfree(85)
 
 initialize_ppu_long:
-    LDA $7E33EA : STA !ram_cgram_cache+$2E
+    LDA !BG3_HDMA_CHANNELS_BACKUP : STA !ram_backup_message_box
     JSR $8143
     ; cm_transfer_custom_tileset will call %ai16()
     RTL
@@ -27,7 +27,7 @@ initialize_ppu_long:
 restore_ppu_long:
     JSR $861A
     %ai16()
-    LDA !ram_cgram_cache+$2E : STA $7E33EA
+    LDA !ram_backup_message_box : STA !BG3_HDMA_CHANNELS_BACKUP
     RTL
 
 play_music_long:

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -1176,7 +1176,7 @@ resume_infohud_icon_initialization:
 ; Category Menus/Data
 ; -------------------
 
-org $E8D800
+org $E8E000
 PresetData:
 check bankcross off
 
@@ -1188,7 +1188,7 @@ print pc, " preset data crossbank end"
 table ../resources/normal.tbl
 incsrc presets/combined_preset_names.asm
 
-warnpc !START_FREESPACE_F0
+warnpc $F08000
 check bankcross on
 
 %startfree(F1)

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -4,8 +4,8 @@
 preset_load:
 {
     PHP
-    LDA !MUSIC_DATA : STA !SRAM_MUSIC_DATA
-    LDA !MUSIC_TRACK : STA !SRAM_MUSIC_TRACK
+    LDA !MUSIC_DATA : STA !ram_loadstate_music_data
+    LDA !MUSIC_TRACK : STA !ram_loadstate_music_track
 
     JSL $809E93  ; Clear timer RAM
     JSR $819B    ; Initialize IO registers
@@ -818,25 +818,25 @@ endif
     LDA !sram_music_toggle : CMP #$0002 : BPL .doneMusic
 
     ; Compare to currently loaded music data
-    LDA !SRAM_MUSIC_DATA : CMP !MUSIC_DATA : BEQ .doneLoadMusicData
+    LDA !ram_loadstate_music_data : CMP !MUSIC_DATA : BEQ .doneLoadMusicData
 
     ; Clear track if necessary
-    LDA !SRAM_MUSIC_TRACK : BEQ .loadMusicData
+    LDA !ram_loadstate_music_track : BEQ .loadMusicData
     TDC : JSL !MUSIC_ROUTINE
 
   .loadMusicData
     LDA !MUSIC_DATA : TAX
-    LDA !SRAM_MUSIC_DATA : STA !MUSIC_DATA
+    LDA !ram_loadstate_music_data : STA !MUSIC_DATA
     TXA : CLC : ADC #$FF00 : JSL !MUSIC_ROUTINE
     BRA .loadMusicTrack
 
   .doneLoadMusicData
     ; Compare to currently playing music
-    LDA !SRAM_MUSIC_TRACK : CMP !MUSIC_TRACK : BEQ .doneMusic
+    LDA !ram_loadstate_music_track : CMP !MUSIC_TRACK : BEQ .doneMusic
 
   .loadMusicTrack
     LDA !MUSIC_TRACK : TAX
-    LDA !SRAM_MUSIC_TRACK : STA !MUSIC_TRACK
+    LDA !ram_loadstate_music_track : STA !MUSIC_TRACK
     TXA : JSL !MUSIC_ROUTINE
 
   .doneMusic

--- a/src/save.asm
+++ b/src/save.asm
@@ -44,20 +44,16 @@ endmacro
 ; Both A and X/Y are 16-bit here
 pre_load_state:
 {
-    LDA !MUSIC_DATA : STA !SRAM_MUSIC_DATA
-    LDA !MUSIC_TRACK : STA !SRAM_MUSIC_TRACK
-    LDA !SOUND_TIMER : STA !SRAM_SOUND_TIMER
-
-    LDA !ram_slowdown_mode : STA !SRAM_SLOWDOWN_MODE
+    LDA !MUSIC_DATA : STA !ram_loadstate_music_data
+    LDA !MUSIC_TRACK : STA !ram_loadstate_music_track
+    LDA !SOUND_TIMER : STA !ram_loadstate_sound_timer
 
     ; Rerandomize
     LDA !sram_save_has_set_rng : BMI .done
     LDA !sram_rerandomize : BEQ .done
-    LDA !CACHED_RANDOM_NUMBER : STA !SRAM_SAVED_RNG
-    LDA !FRAME_COUNTER : STA !SRAM_SAVED_FRAME_COUNTER
-    LDA !ENEMY_MAIN_LOOP_COUNTER : STA !SRAM_SAVED_ENEMY_COUNTER
-    LDA !ram_seed_X : STA !sram_seed_X
-    LDA !ram_seed_Y : STA !sram_seed_Y
+    LDA !CACHED_RANDOM_NUMBER : STA !ram_loadstate_cached_random_number
+    LDA !FRAME_COUNTER : STA !ram_loadstate_frame_counter
+    LDA !ENEMY_MAIN_LOOP_COUNTER : STA !ram_loadstate_enemy_main_loop_counter
 
   .done
     RTS
@@ -94,18 +90,15 @@ post_load_state:
     ; Reload custom HUD number GFX
     JSL overwrite_HUD_numbers
 
-    LDA !SRAM_SLOWDOWN_MODE : STA !ram_slowdown_mode
     TDC : STA !ram_slowdown_frames
     STA !ram_slowdown_controller_1 : STA !ram_slowdown_controller_2
 
     ; Rerandomize
     LDA !sram_save_has_set_rng : BMI .randomizeOnLoad
     LDA !sram_rerandomize : BEQ .randomizeOnLoad
-    LDA !SRAM_SAVED_RNG : STA !CACHED_RANDOM_NUMBER
-    LDA !SRAM_SAVED_FRAME_COUNTER : STA !FRAME_COUNTER
-    LDA !SRAM_SAVED_ENEMY_COUNTER : STA !ENEMY_MAIN_LOOP_COUNTER
-    LDA !sram_seed_X : STA !ram_seed_X
-    LDA !sram_seed_Y : STA !ram_seed_Y
+    LDA !ram_loadstate_cached_random_number : STA !CACHED_RANDOM_NUMBER
+    LDA !ram_loadstate_frame_counter : STA !FRAME_COUNTER
+    LDA !ram_loadstate_enemy_main_loop_counter : STA !ENEMY_MAIN_LOOP_COUNTER
     JSL MenuRNG ; rerandomize hack RNG
 
   .randomizeOnLoad
@@ -181,7 +174,7 @@ post_load_music:
     LDA !sram_music_toggle : CMP #$0002 : BPL .fast_off_preset_off
 
     ; No data found in queue, check if we need to insert it
-    LDA !SRAM_MUSIC_DATA : CMP !MUSIC_DATA : BEQ .music_queue_increase_timer
+    LDA !ram_loadstate_music_data : CMP !MUSIC_DATA : BEQ .music_queue_increase_timer
 
     ; Insert queued music data
     DEX #2 : TXA : AND #$000E : TAX
@@ -197,7 +190,7 @@ post_load_music:
 
   .music_queue_empty
     LDA !sram_music_toggle : CMP #$0002 : BPL .fast_off_preset_off
-    LDA !SRAM_MUSIC_DATA : CMP !MUSIC_DATA : BNE .clear_track_load_data
+    LDA !ram_loadstate_music_data : CMP !MUSIC_DATA : BNE .clear_track_load_data
     JMP .check_track
 
   .clear_track_load_data
@@ -218,7 +211,7 @@ post_load_music:
 
   .music_queue_increase_timer
     ; Data is correct, but we may need to increase our sound timer
-    LDA !SRAM_SOUND_TIMER : CMP !MUSIC_TIMER : BMI .done
+    LDA !ram_loadstate_sound_timer : CMP !MUSIC_TIMER : BMI .done
     STA !MUSIC_TIMER : STA !SOUND_TIMER
     BRA .done
 
@@ -236,7 +229,7 @@ post_load_music:
     LDX !MUSIC_QUEUE_START
 
   .queued_music_prepare_set_timer
-    LDA !SRAM_SOUND_TIMER : BNE .queued_music_set_timer
+    LDA !ram_loadstate_sound_timer : BNE .queued_music_set_timer
     INC
 
   .queued_music_set_timer
@@ -244,7 +237,7 @@ post_load_music:
     BRA .done
 
   .check_track
-    LDA !SRAM_MUSIC_TRACK : CMP !MUSIC_TRACK : BEQ .done
+    LDA !ram_loadstate_music_track : CMP !MUSIC_TRACK : BEQ .done
 
   .load_track
     LDA !MUSIC_TRACK : JSL !MUSIC_ROUTINE

--- a/src/symbols.asm
+++ b/src/symbols.asm
@@ -378,9 +378,6 @@ ram_cm_manage_slots = !ram_cm_manage_slots ; !WRAM_MENU_START+$90
 ram_cm_selected_slot = !ram_cm_selected_slot ; !WRAM_MENU_START+$92
 ram_cm_preset_elevator = !ram_cm_preset_elevator ; !WRAM_MENU_START+$94
 
-; keyboard used by both presets and customize menus
-ram_cm_keyboard_buffer = !ram_cm_keyboard_buffer ; !WRAM_MENU_START+$B8 ; $18 bytes
-
 ram_cm_custompalette_blue = !ram_cm_custompalette_blue ; !WRAM_MENU_START+$90
 ram_cm_custompalette_green = !ram_cm_custompalette_green ; !WRAM_MENU_START+$92
 ram_cm_custompalette_red = !ram_cm_custompalette_red ; !WRAM_MENU_START+$94
@@ -390,13 +387,25 @@ ram_cm_dummy_on = !ram_cm_dummy_on ; !WRAM_MENU_START+$AA
 ram_cm_dummy_off = !ram_cm_dummy_off ; !WRAM_MENU_START+$AC
 ram_cm_dummy_num = !ram_cm_dummy_num ; !WRAM_MENU_START+$AE
 
+; keyboard used by both presets and customize menus
+ram_cm_keyboard_buffer = !ram_cm_keyboard_buffer ; !WRAM_MENU_START+$B8 ; $18 bytes
+
 ; ^ FREE SPACE ^ up to +$CE
 ; Note: +$B8 to +$CE range also used as frames held counters and keyboard buffer
 ;       and is reset to zero when loading a savestate
 
-; Reserve 48 bytes for CGRAM cache
-; Currently first 32 bytes plus last 2 bytes are used
-ram_cgram_cache = !ram_cgram_cache ; !WRAM_MENU_START+$D0 ; $30 bytes
+; load state cannot be initiated from the menu, so it can overlap cgram
+ram_loadstate_music_data = !ram_loadstate_music_data ; !WRAM_MENU_START+$D0
+ram_loadstate_music_track = !ram_loadstate_music_track ; !WRAM_MENU_START+$D2
+ram_loadstate_sound_timer = !ram_loadstate_sound_timer ; !WRAM_MENU_START+$D4
+ram_loadstate_cached_random_number = !ram_loadstate_cached_random_number ; !WRAM_MENU_START+$D6
+ram_loadstate_frame_counter = !ram_loadstate_frame_counter ; !WRAM_MENU_START+$D8
+ram_loadstate_enemy_main_loop_counter = !ram_loadstate_enemy_main_loop_counter ; !WRAM_MENU_START+$DA
+ram_cgram_cache = !ram_cgram_cache ; !WRAM_MENU_START+$D0 ; $20 bytes
+
+ram_backup_message_box = !ram_backup_message_box ; !WRAM_MENU_START+$F0
+
+; ^ FREE SPACE ^ up to +$FE
 
 ; -----------------
 ; Crash Handler RAM
@@ -599,8 +608,6 @@ sram_streamer_name_tinystates = !sram_streamer_name_tinystates ; !SRAM_START+$E0
 sram_custom_header_tinystates = !sram_custom_header_tinystates ; !SRAM_START+$E18 ; $18 bytes
 sram_custom_preset_safewords_tinystates = !sram_custom_preset_safewords_tinystates ; !SRAM_START+$E30 ; $20 bytes
 sram_custom_preset_names_tinystates = !sram_custom_preset_names_tinystates ; !SRAM_START+$E50 ; $180 bytes
-
-; SM specific things
 
 ; ^ FREE SPACE ^ up to +$FFE
 

--- a/src/tilegraphics.asm
+++ b/src/tilegraphics.asm
@@ -1,5 +1,5 @@
 
-org $E68000
+org $E68800
 check bankcross off
 print pc, " raw tile tables crossbank start"
 

--- a/src/tinystates.asm
+++ b/src/tinystates.asm
@@ -44,20 +44,16 @@ endmacro
 ; Both A and X/Y are 16-bit here
 pre_load_state:
 {
-    LDA !MUSIC_DATA : STA !SRAM_MUSIC_DATA
-    LDA !MUSIC_TRACK : STA !SRAM_MUSIC_TRACK
-    LDA !SOUND_TIMER : STA !SRAM_SOUND_TIMER
-
-    LDA !ram_slowdown_mode : STA !SRAM_SLOWDOWN_MODE
+    LDA !MUSIC_DATA : STA !ram_loadstate_music_data
+    LDA !MUSIC_TRACK : STA !ram_loadstate_music_track
+    LDA !SOUND_TIMER : STA !ram_loadstate_sound_timer
 
     ; Rerandomize
     LDA !sram_save_has_set_rng : BMI .done
     LDA !sram_rerandomize : BEQ .done
-    LDA !CACHED_RANDOM_NUMBER : STA !SRAM_SAVED_RNG
-    LDA !FRAME_COUNTER : STA !SRAM_SAVED_FRAME_COUNTER
-    LDA !ENEMY_MAIN_LOOP_COUNTER : STA !SRAM_SAVED_ENEMY_COUNTER
-    LDA !ram_seed_X : STA !sram_seed_X
-    LDA !ram_seed_Y : STA !sram_seed_Y
+    LDA !CACHED_RANDOM_NUMBER : STA !ram_loadstate_cached_random_number
+    LDA !FRAME_COUNTER : STA !ram_loadstate_frame_counter
+    LDA !ENEMY_MAIN_LOOP_COUNTER : STA !ram_loadstate_enemy_main_loop_counter
 
   .done
     ; Force blank and disable NMI
@@ -133,18 +129,15 @@ post_load_state:
     ; Reload custom HUD number GFX
     JSL overwrite_HUD_numbers
 
-    LDA !SRAM_SLOWDOWN_MODE : STA !ram_slowdown_mode
     TDC : STA !ram_slowdown_frames
     STA !ram_slowdown_controller_1 : STA !ram_slowdown_controller_2
 
     ; Rerandomize
     LDA !sram_save_has_set_rng : BMI .randomizeOnLoad
     LDA !sram_rerandomize : BEQ .randomizeOnLoad
-    LDA !SRAM_SAVED_RNG : STA !CACHED_RANDOM_NUMBER
-    LDA !SRAM_SAVED_FRAME_COUNTER : STA !FRAME_COUNTER
-    LDA !SRAM_SAVED_ENEMY_COUNTER : STA !ENEMY_MAIN_LOOP_COUNTER
-    LDA !sram_seed_X : STA !ram_seed_X
-    LDA !sram_seed_Y : STA !ram_seed_Y
+    LDA !ram_loadstate_cached_random_number : STA !CACHED_RANDOM_NUMBER
+    LDA !ram_loadstate_frame_counter : STA !FRAME_COUNTER
+    LDA !ram_loadstate_enemy_main_loop_counter : STA !ENEMY_MAIN_LOOP_COUNTER
     JSL MenuRNG ; rerandomize hack RNG
 
   .randomizeOnLoad
@@ -225,7 +218,7 @@ post_load_music:
     LDA !sram_music_toggle : CMP #$0002 : BPL .fast_off_preset_off
 
     ; No data found in queue, check if we need to insert it
-    LDA !SRAM_MUSIC_DATA : CMP !MUSIC_DATA : BEQ .music_queue_increase_timer
+    LDA !ram_loadstate_music_data : CMP !MUSIC_DATA : BEQ .music_queue_increase_timer
 
     ; Insert queued music data
     DEX #2 : TXA : AND #$000E : TAX
@@ -241,7 +234,7 @@ post_load_music:
 
   .music_queue_empty
     LDA !sram_music_toggle : CMP #$0002 : BPL .fast_off_preset_off
-    LDA !SRAM_MUSIC_DATA : CMP !MUSIC_DATA : BNE .clear_track_load_data
+    LDA !ram_loadstate_music_data : CMP !MUSIC_DATA : BNE .clear_track_load_data
     JMP .check_track
 
   .clear_track_load_data
@@ -262,7 +255,7 @@ post_load_music:
 
   .music_queue_increase_timer
     ; Data is correct, but we may need to increase our sound timer
-    LDA !SRAM_SOUND_TIMER : CMP !MUSIC_TIMER : BMI .done
+    LDA !ram_loadstate_sound_timer : CMP !MUSIC_TIMER : BMI .done
     STA !MUSIC_TIMER : STA !SOUND_TIMER
     BRA .done
 
@@ -280,7 +273,7 @@ post_load_music:
     LDX !MUSIC_QUEUE_START
 
   .queued_music_prepare_set_timer
-    LDA !SRAM_SOUND_TIMER : BNE .queued_music_set_timer
+    LDA !ram_loadstate_sound_timer : BNE .queued_music_set_timer
     INC
 
   .queued_music_set_timer
@@ -288,7 +281,7 @@ post_load_music:
     BRA .done
 
   .check_track
-    LDA !SRAM_MUSIC_TRACK : CMP !MUSIC_TRACK : BEQ .done
+    LDA !ram_loadstate_music_track : CMP !MUSIC_TRACK : BEQ .done
 
   .load_track
     LDA !MUSIC_TRACK : JSL !MUSIC_ROUTINE


### PR DESCRIPTION
Also fix a couple issues in the next-update branch.

Even though tile tables uses crossbank, the starting value of $E68800 was chosen so each tile table fits within a bank.  Starting at $E68000 was causing some issues (try jumping to LN or bubble mountain preset).  Also made freespace report the $800 bytes available at the start of bank $E6 (which I had forgotten existed, so nice to know about).