### PR TITLE
Optimize Metroid and Zeb menu code (round 2)

### DIFF
--- a/src/flagmenu.asm
+++ b/src/flagmenu.asm
@@ -828,41 +828,16 @@ eventflags_setmapstations:
 
 eventflags_prepare_events_menu:
 {
-    ; Zebettites
-    LDA $7ED820 : AND #$0038
-    CMP #$0020 : BEQ .fourZeb
-    CMP #$0018 : BEQ .threeZeb
-    CMP #$0010 : BEQ .twoZeb
-    CMP #$0008 : BEQ .oneZeb
-    LDA #$0000 : BRA .doneZeb
-  .fourZeb
-    LDA #$0004 : BRA .doneZeb
-  .threeZeb
-    LDA #$0003 : BRA .doneZeb
-  .twoZeb
-    LDA #$0002 : BRA .doneZeb
-  .oneZeb
-    LDA #$0001 : BRA .doneZeb
-  .doneZeb
-    STA !ram_cm_zebmask
-
     ; Metroids
     LDA $7ED822 : AND #$000F
-    BIT #$0008 : BNE .fourMet
-    BIT #$0004 : BNE .threeMet
-    BIT #$0002 : BNE .twoMet
-    BIT #$0001 : BNE .oneMet
-    LDA #$0000 : BRA .doneMet
-  .fourMet
-    LDA #$0004 : BRA .doneMet
-  .threeMet
-    LDA #$0003 : BRA .doneMet
-  .twoMet
-    LDA #$0002 : BRA .doneMet
-  .oneMet
-    LDA #$0001 : BRA .doneMet
-  .doneMet
-    STA !ram_cm_metmask
+    LDX #$FFFF
+  .metLoop
+    INX
+    LSR : BCS .metLoop
+    TXA : STA !ram_cm_metmask
+
+    ; Zebetites
+    LDA $7ED820 : AND #$0038 : LSR #3 : STA !ram_cm_zebmask
 
     %setmenubank()
     JML action_submenu
@@ -906,7 +881,7 @@ events_chozoacid:
 events_metroids:
     %cm_numfield("Metroid Rooms Cleared", !ram_cm_metmask, 0, 4, 1, 1, #.routine)
   .routine
-    CMP #$0000 : BEQ .done
+    TAX : BEQ .done
     DEC : ASL : TAX
     LDA.l .table,X
   .done
@@ -919,15 +894,9 @@ events_metroids:
 events_zebettites:
     %cm_numfield("Zebs Killed", !ram_cm_zebmask, 0, 4, 1, 1, #.routine)
   .routine
-    CMP #$0000 : BEQ .done
-    DEC : ASL : TAX
-    LDA.l .table,X
-  .done
-    STA $C1
+    ASL #3 : STA $C1
     LDA $7ED820 : AND #$FFC7 : ORA $C1 : STA $7ED820
     RTL
-  .table
-    dw $0008, $0010, $0018, $0020
 
 events_mb1glass:
     %cm_toggle_bit("MB1 Glass Broken", $7ED820, #$0004, #0)

--- a/src/main.asm
+++ b/src/main.asm
@@ -16,8 +16,8 @@ lorom
 
 !VERSION_MAJOR = 2
 !VERSION_MINOR = 7
-!VERSION_BUILD = 9
-!VERSION_REV   = 1
+!VERSION_BUILD = 10
+!VERSION_REV   = 0
 
 table ../resources/normal.tbl
 print ""

--- a/web/data/changelog.mdx
+++ b/web/data/changelog.mdx
@@ -64,6 +64,7 @@
 - Rerandomize on load now runs extra RNG calls (2.7.9)
 - Update timers routine optimized and accounted for by artificial lag (2.7.9)
 - Clear BG1 VRAM when loading presets to improve screen-shake artifacts (2.7.9.1)
+- Added options to prevent savestates and custom presets from being overwritten (2.7.10)
 
 # Version 2.6.x
 - Optimize kraid rock projectiles to reduce lag when Kraid rises (2.6.0)

--- a/web/data/config.json
+++ b/web/data/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Super Metroid Practice Hack",
-    "version": "2.7.9.1",
+    "version": "2.7.10",
     "variants": ["NTSC", "PAL"],
     "base": {
         "NTSC": {

--- a/web/data/help.mdx
+++ b/web/data/help.mdx
@@ -67,7 +67,10 @@ If you experience crashes or severe glitches when using savestates, your platfor
 | - Custom Preset Slot          | Select one of 40 slots in memory to save or load custom presets. Press A to open a submenu with a list of preset slots.
 |                               | Press Y in the submenu to toggle the display between room names and Samus data.
 |                               | Press X in the submenu to provide a custom preset name.
-|                               | Use the Manage Custom Presets option at the bottom to swap or delete slots.
+|                               | Use the Manage Custom Presets option at the bottom to swap, lock, or delete slots.
+|                               | Press A to select a slot. Move to another slot and press A again to swap the two slots.
+|                               | Press X to delete the custom preset in the selected slot. A confirmation page is provided.
+|                               | Press Y to toggle the read-only lock, preventing the custom preset from being deleted or overwritten.
 | - Save Custom Preset          | Save a custom preset to the current slot in SRAM.
 |                               | A grapple sound effect will play if a preset cannot be saved (for example during room transition).
 | - Load Custom Preset          | Load the custom preset in the current slot in SRAM.
@@ -237,6 +240,7 @@ If you experience crashes or severe glitches when using savestates, your platfor
 |                               | It also resets the segment timer. Beware that since it leverages the existing frame advance feature, toggling this on changes the way frame advance works.
 | - Auto-Save Mid Door          | Creates a savestate in the middle of the next door transition.
 | - Auto-Save Every Door        | Creates a savestate in the middle of every door transition.
+| - Read-Only Lock              | Prevents a savestate from being overwritten.
 | - Energy/Ammo Variance        | Set ranges allowing resources to vary randomly when you reload a savestate.
 |&nbsp;|
 | **Slowdown Mode**             | Set if practice hack is in slowdown mode and the number of lag frames it is set for.


### PR DESCRIPTION
Saved 62 bytes

I forgot to include docs for read-only locks, so that's here too.