### PR TITLE
Fix potential crash when loading presets

### DIFF
--- a/src/main.asm
+++ b/src/main.asm
@@ -17,7 +17,7 @@ lorom
 !VERSION_MAJOR = 2
 !VERSION_MINOR = 7
 !VERSION_BUILD = 11
-!VERSION_REV   = 0
+!VERSION_REV   = 1
 
 table ../resources/normal.tbl
 print ""

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -758,7 +758,7 @@ endif
 
     JSL Randomize_Preset_Equipment
     JSL $90AC8D ; Update beam graphics
-    JSL $82E139 ; Load target colours for common sprites, beams and slashing enemies / pickups
+    JSL load_common_target_colors
 if !FEATURE_PAL
     JSL $A08A2E
 else ; Load enemies

--- a/web/data/changelog.mdx
+++ b/web/data/changelog.mdx
@@ -68,6 +68,7 @@
 - Minor updates to KPDR Kraid presets (2.7.10)
 - Fix PAL bug where skipping a frame of gameplay could result in segment timer overflowing (2.7.11)
 - New option to save two tinystates instead of one full savestate (2.7.11)
+- Fix potential crash when loading presets (2.7.11.1)
 
 # Version 2.6.x
 - Optimize kraid rock projectiles to reduce lag when Kraid rises (2.6.0)

--- a/web/data/config.json
+++ b/web/data/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Super Metroid Practice Hack",
-    "version": "2.7.11",
+    "version": "2.7.11.1",
     "variants": ["NTSC", "PAL"],
     "base": {
         "NTSC": {


### PR DESCRIPTION
I was experimenting with making demos load faster in the practice hack by copying `preset_start_gameplay`. I came across a crash after cutting out some things that were specific to presets. The hitbox color feature overwrote a stray RTL to expand the routine below it. `preset_start_gameplay` was calling the old address. The routine is supposed to start like this
```
load_common_target_colors:
    %ai16()
    LDX #$001E
  .first_loop
    LDA $9A81A0,X : STA $7EC3A0,X
    DEX #2 : BPL .first_loop
```
But it worked out to this on the first loop
```
    db $C2 ; the skipped byte that used to be RTL
load_common_target_colors:
    BMI $A2 ; crash if negative flag is set
    ASL $BF00,X
    LDY #$9A81
    STA $7EC3A0,X
    DEX #2
    BPL .first_loop
```
We don't notice the effects of this because X = $20, only one extra loop. The fix is replacing `JSL $82E139` with `JSL load_common_target_colors` in presets.asm